### PR TITLE
Taking out verify_session for ibm cloud

### DIFF
--- a/node-scenarios/plugin_node_scenario.yaml.template
+++ b/node-scenarios/plugin_node_scenario.yaml.template
@@ -10,7 +10,6 @@
     instance_count: $INSTANCE_COUNT
     # Duration to wait for completion of node scenario injection              
     timeout: $TIMEOUT
-    # Set to True if you want to verify the vSphere client session using certificates; else False
-    verify_session: $VERIFY_SESSION
+    $VERIFY_SESSION
     # Set to True if you don't want to wait for the status of the nodes to change on OpenShift before passing the scenario
     skip_openshift_checks: $SKIP_OPENSHIFT_CHECKS

--- a/node-scenarios/run.sh
+++ b/node-scenarios/run.sh
@@ -11,9 +11,22 @@ checks
 
 # Substitute config with environment vars defined
 if [[ "$CLOUD_TYPE" == "vmware" || "$CLOUD_TYPE" == "ibmcloud" ]]; then
-  envsubst < /home/krkn/kraken/scenarios/plugin_node_scenario.yaml.template > /home/krkn/kraken/scenarios/node_scenario.yaml
-  export SCENARIO_TYPE="plugin_scenarios"
   export ACTION=${ACTION:="$CLOUD_TYPE-node-reboot"}
+  envsubst < /root/kraken/scenarios/plugin_node_scenario.yaml.template > /root/kraken/scenarios/node_scenario.yaml
+  export SCENARIO_TYPE="plugin_scenarios"
+
+  # IBM doesnt have verify session
+  # Invalid parameter 'verify_session', expected one of: name, runs, label_selector, timeout, instance_count, skip_openshift_checks, kubeconfig_path
+  if [[ "$CLOUD_TYPE" == "vmware" ]]; then
+    
+    ## Set to True if you want to verify the vSphere client session using certificates; else False
+    export VERIFY_SESSION="verify_session: $VERIFY_SESSION"
+  else
+    export VERIFY_SESSION=""
+  fi
+
+
+
 else
   envsubst < /home/krkn/kraken/scenarios/node_scenario.yaml.template > /home/krkn/kraken/scenarios/node_scenario.yaml
 fi


### PR DESCRIPTION
` Invalid parameter 'verify_session', expected one of: name, runs, label_selector, timeout, instance_count, skip_openshift_checks, kubeconfig_path
  `
  
 https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/52581/rehearse-52581-pull-ci-redhat-chaos-prow-scripts-main-4.16-nightly-krkn-hub-ibm-cloud-api-tests/1815385285932879872