### PR TITLE
Ibm checks

### DIFF
--- a/node-scenarios/plugin_node_scenario.yaml.template
+++ b/node-scenarios/plugin_node_scenario.yaml.template
@@ -12,4 +12,4 @@
     timeout: $TIMEOUT
     $VERIFY_SESSION
     # Set to True if you don't want to wait for the status of the nodes to change on OpenShift before passing the scenario
-    skip_openshift_checks: $SKIP_OPENSHIFT_CHECKS
+    $SKIP_OPENSHIFT_CHECKS

--- a/node-scenarios/run.sh
+++ b/node-scenarios/run.sh
@@ -18,10 +18,11 @@ if [[ "$CLOUD_TYPE" == "vmware" || "$CLOUD_TYPE" == "ibmcloud" ]]; then
   # IBM doesnt have verify session
   # Invalid parameter 'verify_session', expected one of: name, runs, label_selector, timeout, instance_count, skip_openshift_checks, kubeconfig_path
   if [[ "$CLOUD_TYPE" == "vmware" ]]; then
-    
     ## Set to True if you want to verify the vSphere client session using certificates; else False
     export VERIFY_SESSION="verify_session: $VERIFY_SESSION"
+    export SKIP_OPENSHIFT_CHECKS="skip_openshift_checks: $SKIP_OPENSHIFT_CHECKS"
   else
+    export SKIP_OPENSHIFT_CHECKS=""
     export VERIFY_SESSION=""
   fi
   envsubst < /home/krkn/kraken/scenarios/plugin_node_scenario.yaml.template > /home/krkn/kraken/scenarios/node_scenario.yaml


### PR DESCRIPTION
From an older run in prow:  https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/52581/rehearse-52581-pull-ci-redhat-chaos-prow-scripts-main-4.16-nightly-krkn-hub-ibm-cloud-api-tests/1816140369155330048



```
2024-07-24 17:26:18,667 [INFO] scenario /tmp/node_scenario.yaml
2024-07-24 17:26:18,669 [ERROR] scenario exception: Validation failed for 'NodeScenarioConfig -> name': This field is required because 'skip_openshift_checks' is set
2024-07-24 17:26:18,669 [ERROR] scenario: /tmp/node_scenario.yaml failed with exception: <class 'arcaflow_plugin_sdk.schema.ConstraintException'> file: /tmp/kraken/kraken/plugins/__init__.py line: 273
2024
```