### PR TITLE
Adding new scenario type

### DIFF
--- a/node-scenarios/run.sh
+++ b/node-scenarios/run.sh
@@ -10,21 +10,25 @@ source /home/krkn/common_run.sh
 checks
 
 # Substitute config with environment vars defined
-if [[ "$CLOUD_TYPE" == "vmware" || "$CLOUD_TYPE" == "ibmcloud" ]]; then
+if [[ "$CLOUD_TYPE" == "vmware" ]]; then
+  export ACTION=${ACTION:="$CLOUD_TYPE-node-reboot"}
+  ## Set to True if you want to verify the vSphere client session using certificates; else False
+  export VERIFY_SESSION="verify_session: $VERIFY_SESSION"
+  export SKIP_OPENSHIFT_CHECKS="skip_openshift_checks: $SKIP_OPENSHIFT_CHECKS"
+
+  export SCENARIO_TYPE="vmware_node_scenarios"
+  envsubst < /home/krkn/kraken/scenarios/plugin_node_scenario.yaml.template > /home/krkn/kraken/scenarios/node_scenario.yaml
+elif [[ "$CLOUD_TYPE" == "ibmcloud" ]]; then
   export ACTION=${ACTION:="$CLOUD_TYPE-node-reboot"}
   
-  export SCENARIO_TYPE="plugin_scenarios"
+  export SCENARIO_TYPE="ibmcloud_node_scenarios"
 
   # IBM doesnt have verify session
   # Invalid parameter 'verify_session', expected one of: name, runs, label_selector, timeout, instance_count, skip_openshift_checks, kubeconfig_path
-  if [[ "$CLOUD_TYPE" == "vmware" ]]; then
-    ## Set to True if you want to verify the vSphere client session using certificates; else False
-    export VERIFY_SESSION="verify_session: $VERIFY_SESSION"
-    export SKIP_OPENSHIFT_CHECKS="skip_openshift_checks: $SKIP_OPENSHIFT_CHECKS"
-  else
-    export SKIP_OPENSHIFT_CHECKS=""
-    export VERIFY_SESSION=""
-  fi
+
+  export SKIP_OPENSHIFT_CHECKS=""
+  export VERIFY_SESSION=""
+
   envsubst < /home/krkn/kraken/scenarios/plugin_node_scenario.yaml.template > /home/krkn/kraken/scenarios/node_scenario.yaml
 
 elif [[ "$CLOUD_TYPE" == "bm" ]]; then


### PR DESCRIPTION
Node scenarios have a new scenario type 


https://github.com/krkn-chaos/krkn/blob/04e44738d9507b5da4346843c7580494d433c602/config/config.yaml#L29-L32

Failure in prow seen here: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/57555/rehearse-57555-pull-ci-redhat-chaos-prow-scripts-main-4.18-nightly-krkn-hub-ibm-cloud-api-tests/1846315894603517952

Will also need to update prow-scripts with same change