### PR TITLE
Adding gcp zone outage type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea/
+*/Dockerfile
+.DS_Store

--- a/zone-outages/Dockerfile.template
+++ b/zone-outages/Dockerfile.template
@@ -11,6 +11,7 @@ COPY zone-outages/env.sh /home/krkn/env.sh
 COPY env.sh /home/krkn/main_env.sh
 COPY zone-outages/run.sh /home/krkn/run.sh
 COPY zone-outages/zone_outage_scenario.yaml.template /home/krkn/kraken/scenarios/zone_outage_scenario.yaml.template
+COPY zone-outages/zone_outage_scenario_gcp.yaml.template /home/krkn/kraken/scenarios/zone_outage_scenario_gcp.yaml.template
 COPY common_run.sh /home/krkn/common_run.sh
 
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"

--- a/zone-outages/env.sh
+++ b/zone-outages/env.sh
@@ -7,5 +7,6 @@ export DURATION=${DURATION:=600}
 export VPC_ID=${VPC_ID:=""}
 export SUBNET_ID=${SUBNET_ID:=""}
 export DEFAULT_ACL_ID=${DEFAULT_ACL_ID:=""}
+export ZONE=${ZONE:=""}
 export SCENARIO_TYPE=${SCENARIO_TYPE:=zone_outages_scenarios}
 export SCENARIO_FILE=${SCENARIO_FILE:=scenarios/zone_outage.yaml}

--- a/zone-outages/krknctl-input.json
+++ b/zone-outages/krknctl-input.json
@@ -1,69 +1,83 @@
 [
     {
-        "name":"cloud-type",
-	    "short_description":"Cloud Type",
-        "description":"Cloud platform on top of which cluster is running",
-        "variable":"CLOUD_TYPE",
-        "type":"enum",
-        "allowed_values": "aws",
-        "separator":",",
-        "default":"aws",
+        "name": "cloud-type",
+        "short_description": "Cloud Type",
+        "description": "Cloud platform on top of which cluster is running",
+        "variable": "CLOUD_TYPE",
+        "type": "enum",
+        "allowed_values": "aws,gcp",
+        "separator": ",",
+        "default": "aws",
         "required": "false"
     },
-    
     {
-        "name":"duration",
-        "short_description":"Chaos Duration",
-        "description":"Duration in seconds after which the zone will be back online",
-        "variable":"DURATION",
-        "type":"number",
-        "default":"600",
-        "required":"false"
+        "name": "duration",
+        "short_description": "Chaos Duration",
+        "description": "Duration in seconds after which the zone will be back online",
+        "variable": "DURATION",
+        "type": "number",
+        "default": "600",
+        "required": "false"
     },
     {
-        "name":"vpc-id",
-        "short_description":"VPC-ID",
-        "description":"cluster virtual private network to target",
-        "variable":"VPC_ID",
-        "type":"string",
-        "required":"true"
+        "name": "vpc-id",
+        "short_description": "VPC-ID",
+        "description": "cluster virtual private network to target",
+        "variable": "VPC_ID",
+        "type": "string",
+        "required": "true"
     },
     {
-        "name":"subnet-id",
-        "short_description":"SUBNET_ID",
-        "description":"subnet-id to deny both ingress and egress traffic ( REQUIRED ). Format: [subnet1, subnet2]",
-        "variable":"SUBNET_ID",
-        "type":"string",
-        "validator":"^$|^\\[([a-zA-Z0-9._-](,)?)+[^,]\\]$",
-        "required":"false"
+        "name": "subnet-id",
+        "short_description": "SUBNET_ID",
+        "description": "subnet-id to deny both ingress and egress traffic ( REQUIRED ). Format: [subnet1, subnet2]",
+        "variable": "SUBNET_ID",
+        "type": "string",
+        "validator": "^$|^\\[([a-zA-Z0-9._-](,)?)+[^,]\\]$",
+        "required": "false"
     },
     {
-        "name":"aws-access-key-id",
-	    "short_description":"AWS Access Key Id[*AWS only*]",
-        "description":"AWS Access Key Id",
-        "variable":"AWS_ACCESS_KEY_ID",
-        "type":"string",
-        "default":"",
-        "required":"false"
+        "name": "aws-access-key-id",
+        "short_description": "AWS Access Key Id[*AWS only*]",
+        "description": "AWS Access Key Id",
+        "variable": "AWS_ACCESS_KEY_ID",
+        "type": "string",
+        "default": "",
+        "required": "false"
     },
     {
-        "name":"aws-secret-access-key",
-	    "short_description":"AWS Secret Access Key [*AWS only*]",
-        "description":"AWS Secret Access Key",
-        "variable":"AWS_SECRET_ACCESS_KEY",
-        "type":"string",
-        "default":"",
-        "required":"false"
+        "name": "aws-secret-access-key",
+        "short_description": "AWS Secret Access Key [*AWS only*]",
+        "description": "AWS Secret Access Key",
+        "variable": "AWS_SECRET_ACCESS_KEY",
+        "type": "string",
+        "default": "",
+        "required": "false"
     },
     {
-        "name":"aws-default-region",
-	    "short_description":"AWS default region [*AWS only*]",
-        "description":"AWS default region",
-        "variable":"AWS_DEFAULT_REGION",
-        "type":"string",
-        "default":"",
-        "required":"false"
+        "name": "aws-default-region",
+        "short_description": "AWS default region [*AWS only*]",
+        "description": "AWS default region",
+        "variable": "AWS_DEFAULT_REGION",
+        "type": "string",
+        "default": "",
+        "required": "false"
+    },
+    {
+        "name": "zone",
+        "short_description": "ZONE",
+        "description": "cluster zone to target",
+        "variable": "ZONE",
+        "type": "string",
+        "required": "true"
+    },
+    {
+        "name": "gcp-application-credentials",
+        "short_description": "GCP application credentials [*GCP only*]",
+        "description": "GCP application credentials file location",
+        "variable": "GOOGLE_APPLICATION_CREDENTIALS",
+        "type": "string",
+        "default": "",
+        "required": "false"
     }
-
-
 ]

--- a/zone-outages/run.sh
+++ b/zone-outages/run.sh
@@ -10,8 +10,12 @@ fi
 
 checks
 
+if [[ "$CLOUD_TYPE" == "gcp" ]]; then
 # Substitute config with environment vars defined
-envsubst < /home/krkn/kraken/scenarios/zone_outage_scenario.yaml.template > /home/krkn/kraken/scenarios/zone_outage.yaml
+  envsubst < /home/krkn/kraken/scenarios/zone_outage_scenario_gcp.yaml.template > /home/krkn/kraken/scenarios/zone_outage.yaml
+else 
+  envsubst < /home/krkn/kraken/scenarios/zone_outage_scenario.yaml.template > /home/krkn/kraken/scenarios/zone_outage.yaml
+fi 
 envsubst < /home/krkn/kraken/config/config.yaml.template > /home/krkn/kraken/config/zone_config.yaml
 
 # Run Kraken

--- a/zone-outages/zone_outage_scenario_gcp.yaml.template
+++ b/zone-outages/zone_outage_scenario_gcp.yaml.template
@@ -1,0 +1,4 @@
+zone_outage:                                         # Scenario to create an outage of a zone by tweaking network ACL
+  cloud_type: $CLOUD_TYPE                            # cloud type on which Kubernetes/OpenShift runs. aws is only platform supported currently for this scenario.
+  duration: $DURATION                                # duration in seconds after which the zone will be back online
+  zone: $ZONE                                   # cluster virtual private network to target


### PR DESCRIPTION
## Description  
Adding gcp option to zone outages. Used -v option to copy over google credential file and added to variable list on command line


`podman run -e CLOUD_TYPE=gcp -e ZONE=us-central1-b -e GOOGLE_APPLICATION_CREDENTIALS=/home/krkn/GCP_app.json -e DURATION=10 --net=host  -v /**/kubeconfig:/home/krkn/.kube/config:Z -v /***/chaos_ci_gcp.json:/home/krkn/GCP_app.json:Z -d quay.io/krkn-chaos/krkn-hub:zone-outages  `


## Documentation  
- [] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/). 

Already updated documentation here 
## Related Documentation PR (if applicable)  
[<!-- Add the link to the corresponding documentation PR in the website repository -->  ](https://github.com/krkn-chaos/website/pull/34)