### PR TITLE
Adding kube_check to node scenarios

### DIFF
--- a/node-scenarios/env.sh
+++ b/node-scenarios/env.sh
@@ -14,7 +14,7 @@ export SCENARIO_TYPE=${SCENARIO_TYPE:=node_scenarios}
 export SCENARIO_FILE=${SCENARIO_FILE:=scenarios/node_scenario.yaml}
 export VERIFY_SESSION=${VERIFY_SESSION:="false"}
 export SKIP_OPENSHIFT_CHECKS=${SKIP_OPENSHIFT_CHECKS:="false"}
-
+export KUBE_CHECK=${KUBE_CHECK:=True}
 
 # Baremetal vars
 export BMC_USER=${BMC_USER:=""}

--- a/node-scenarios/krknctl-input.json
+++ b/node-scenarios/krknctl-input.json
@@ -47,6 +47,28 @@
         "required": "false"
     },
     {
+        "name": "kube-check",
+        "short_description": "Kube Check",
+        "description": "Connect to the kubernetes api to see if the node gets to a certain state during the node scenario",
+        "variable": "KUBE_CHECK",
+        "type": "enum",
+        "allowed_values": "true,false",
+        "separator": ",",
+        "default": "true",
+        "required": "false"
+    },
+    {
+        "name": "parallel",
+        "short_description": "Parallel",
+        "description": "Run action on label or node name in parallel or sequential, defaults to sequential (false)",
+        "variable": "PARALLEL",
+        "type": "enum",
+        "allowed_values": "true,false",
+        "separator": ",",
+        "default": "false",
+        "required": "false"
+    },
+    {
         "name": "cloud-type",
         "short_description": "Cloud Type",
         "description": "Cloud platform on top of which cluster is running, supported platforms - aws, azure, gcp, vmware, ibmcloud, bm",

--- a/node-scenarios/node_scenario.yaml.template
+++ b/node-scenarios/node_scenario.yaml.template
@@ -9,3 +9,4 @@ node_scenarios:
     duration: $DURATION                                             # duration to stop the node before running the start action
     cloud_type: $CLOUD_TYPE                                         # cloud type on which Kubernetes/OpenShift runs
     parallel: $PARALLEL                                             # Run action on label or node name in parallel or sequential, set to true for parallel
+    kube_check: $KUBE_CHECK


### PR DESCRIPTION
## Description  
Adding in kube check option into node scenarios to get around if kubernetes API goes does during the scenario

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/). 

## Related Documentation PR (if applicable)  
[85](https://github.com/krkn-chaos/website/pull/85)