### PR TITLE
adds support for network filter workload image override

### DIFF
--- a/node-network-filter/env.sh
+++ b/node-network-filter/env.sh
@@ -9,4 +9,4 @@ export INTERFACES=${INTERFACES:=""}
 export PORTS=${PORTS:=""}
 export SCENARIO_TYPE=${SCENARIO_TYPE:=network_chaos_ng_scenarios}
 export SCENARIO_FILE=${SCENARIO_FILE:=scenarios/kube/network-filter.yml}
-export WORKLOAD_IMAGE=${WORKLOAD_IMAGE:="quay.io/krkn-chaos/krkn-network-chaos:latest"}
+export IMAGE=${IMAGE:="quay.io/krkn-chaos/krkn-network-chaos:latest"}

--- a/node-network-filter/env.sh
+++ b/node-network-filter/env.sh
@@ -9,3 +9,4 @@ export INTERFACES=${INTERFACES:=""}
 export PORTS=${PORTS:=""}
 export SCENARIO_TYPE=${SCENARIO_TYPE:=network_chaos_ng_scenarios}
 export SCENARIO_FILE=${SCENARIO_FILE:=scenarios/kube/network-filter.yml}
+export WORKLOAD_IMAGE=${WORKLOAD_IMAGE:="quay.io/krkn-chaos/krkn-network-chaos:latest"}

--- a/node-network-filter/krknctl-input.json
+++ b/node-network-filter/krknctl-input.json
@@ -1,84 +1,93 @@
 [
-    {
-       "name":"chaos-duration",
-       "short_description":"Chaos Duration",
-       "description":"Set chaos duration (in sec) as desired",
-       "variable":"TOTAL_CHAOS_DURATION",
-       "type":"number",
-       "default":"60",
-       "required":"false"
-    },
-    {
-       "name":"node-selector",
-       "short_description":"Node Selector",
-       "description":"Node selector where the scenario containers will be scheduled in the format \"<selector>=<value>\". NOTE:  Will be instantiated a container per each node selected with the same scenario options. If left empty a random node will be selected",
-       "variable":"NODE_SELECTOR",
-       "type":"string",
-       "validator":"^$|^.+\\=.*$",
-       "default":"",
-       "required":"false"
-    },
-    {
-       "name":"namespace",
-       "short_description":"Namespace",
-       "description":"Namespace where the scenario container will be deployed",
-       "variable":"NAMESPACE",
-       "type":"string",
-       "default":"default",
-       "required":"false"
-    },
-    {
-       "name":"instance-count",
-       "short_description":"Number of instances to target",
-       "description":"Number of instances to target if more the one is selected by the NODE_SELECTOR",
-       "variable":"INSTANCE_COUNT",
-       "type":"number",
-       "default":"1",
-       "required":"false"
-    },
-    {
-       "name":"execution",
-       "short_description":"Execution mode",
-       "description":"When multiple nodes are selected the execution on all of them can be performed in serial or in parallel",
-       "variable":"EXECUTION",
-       "type":"enum",
-       "allowed_values":"parallel,serial",
-       "separator":",",
-       "required":"false"
-    },
-    {
-       "name":"ingress",
-       "short_description":"Filter incoming traffic",
-       "description":"Incoming network traffic will be filtered",
-       "variable":"INGRESS",
-       "type":"boolean",
-       "required":"true"
-    },
-    {
-       "name":"egress",
-       "short_description":"Filter outgoing traffic",
-       "description":"Outgoing network traffic will be filtered",
-       "variable":"EGRESS",
-       "type":"boolean",
-       "required":"true"
-    },
-    {
-       "name":"interfaces",
-       "short_description":"Network interfaces to filter outgoing traffic (if more than one separated by comma)",
-       "description":"Network interfaces to filter outgoing traffic (if more than one separated by comma eg. eth0,eth1,eth2)",
-       "variable":"INTERFACES",
-       "type":"string",
-       "default":"",
-       "validator":"^$|^[a-zA-Z0-9]+(,[a-zA-Z0-9]+)*$",
-       "required":"false"
-    },
-    {
-       "name":"ports",
-       "short_description":"Network ports to filter traffic (if more than one separated by comma)",
-       "description":"Network ports to filter traffic (if more than one separated by comma eg. 8080,8081,8082)",
-       "variable":"PORTS",
-       "type":"string",
-       "validator":"^\\d+(,\\d+)*$",
-       "required":"true"
-    }
- ]
+  {
+    "name": "chaos-duration",
+    "short_description": "Chaos Duration",
+    "description": "Set chaos duration (in sec) as desired",
+    "variable": "TOTAL_CHAOS_DURATION",
+    "type": "number",
+    "default": "60",
+    "required": "false"
+  },
+  {
+    "name": "node-selector",
+    "short_description": "Node Selector",
+    "description": "Node selector where the scenario containers will be scheduled in the format \"<selector>=<value>\". NOTE:  Will be instantiated a container per each node selected with the same scenario options. If left empty a random node will be selected",
+    "variable": "NODE_SELECTOR",
+    "type": "string",
+    "validator": "^$|^.+\\=.*$",
+    "default": "",
+    "required": "false"
+  },
+  {
+    "name": "namespace",
+    "short_description": "Namespace",
+    "description": "Namespace where the scenario container will be deployed",
+    "variable": "NAMESPACE",
+    "type": "string",
+    "default": "default",
+    "required": "false"
+  },
+  {
+    "name": "instance-count",
+    "short_description": "Number of instances to target",
+    "description": "Number of instances to target if more the one is selected by the NODE_SELECTOR",
+    "variable": "INSTANCE_COUNT",
+    "type": "number",
+    "default": "1",
+    "required": "false"
+  },
+  {
+    "name": "execution",
+    "short_description": "Execution mode",
+    "description": "When multiple nodes are selected the execution on all of them can be performed in serial or in parallel",
+    "variable": "EXECUTION",
+    "type": "enum",
+    "allowed_values": "parallel,serial",
+    "separator": ",",
+    "required": "false"
+  },
+  {
+    "name": "ingress",
+    "short_description": "Filter incoming traffic",
+    "description": "Incoming network traffic will be filtered",
+    "variable": "INGRESS",
+    "type": "boolean",
+    "required": "true"
+  },
+  {
+    "name": "egress",
+    "short_description": "Filter outgoing traffic",
+    "description": "Outgoing network traffic will be filtered",
+    "variable": "EGRESS",
+    "type": "boolean",
+    "required": "true"
+  },
+  {
+    "name": "interfaces",
+    "short_description": "Network interfaces to filter outgoing traffic (if more than one separated by comma)",
+    "description": "Network interfaces to filter outgoing traffic (if more than one separated by comma eg. eth0,eth1,eth2)",
+    "variable": "INTERFACES",
+    "type": "string",
+    "default": "",
+    "validator": "^$|^[a-zA-Z0-9]+(,[a-zA-Z0-9]+)*$",
+    "required": "false"
+  },
+  {
+    "name": "ports",
+    "short_description": "Network ports to filter traffic (if more than one separated by comma)",
+    "description": "Network ports to filter traffic (if more than one separated by comma eg. 8080,8081,8082)",
+    "variable": "PORTS",
+    "type": "string",
+    "validator": "^\\d+(,\\d+)*$",
+    "required": "true"
+  },
+  {
+    "name": "workload-image",
+    "short_description": "The network chaos injection workload container image",
+    "description": "The network chaos injection workload container image",
+    "variable": "WORKLOAD_IMAGE",
+    "type": "string",
+    "default": "quay.io/krkn-chaos/krkn-network-chaos:latest",
+    "required": "false"
+  }
+]

--- a/node-network-filter/krknctl-input.json
+++ b/node-network-filter/krknctl-input.json
@@ -82,10 +82,10 @@
     "required": "true"
   },
   {
-    "name": "workload-image",
+    "name": "image",
     "short_description": "The network chaos injection workload container image",
     "description": "The network chaos injection workload container image",
-    "variable": "WORKLOAD_IMAGE",
+    "variable": "IMAGE",
     "type": "string",
     "default": "quay.io/krkn-chaos/krkn-network-chaos:latest",
     "required": "false"

--- a/node-network-filter/run.sh
+++ b/node-network-filter/run.sh
@@ -20,7 +20,7 @@ yq -i ".[0].instance_count=$INSTANCE_COUNT" $SCENARIO_FOLDER/network-filter.yml
 yq -i ".[0].execution=\"$EXECUTION\"" $SCENARIO_FOLDER/network-filter.yml
 yq -i ".[0].ingress=\"$INGRESS\"" $SCENARIO_FOLDER/network-filter.yml
 yq -i ".[0].egress=\"$EGRESS\"" $SCENARIO_FOLDER/network-filter.yml
-yq -i ".[0].workload_image=\"$WORKLOAD_IMAGE\"" $SCENARIO_FOLDER/network-filter.yml
+yq -i ".[0].image=\"$IMAGE\"" $SCENARIO_FOLDER/network-filter.yml
 
 IFS=',' read -ra array <<< "$INTERFACES"
 

--- a/node-network-filter/run.sh
+++ b/node-network-filter/run.sh
@@ -20,6 +20,7 @@ yq -i ".[0].instance_count=$INSTANCE_COUNT" $SCENARIO_FOLDER/network-filter.yml
 yq -i ".[0].execution=\"$EXECUTION\"" $SCENARIO_FOLDER/network-filter.yml
 yq -i ".[0].ingress=\"$INGRESS\"" $SCENARIO_FOLDER/network-filter.yml
 yq -i ".[0].egress=\"$EGRESS\"" $SCENARIO_FOLDER/network-filter.yml
+yq -i ".[0].workload_image=\"$WORKLOAD_IMAGE\"" $SCENARIO_FOLDER/network-filter.yml
 
 IFS=',' read -ra array <<< "$INTERFACES"
 


### PR DESCRIPTION
## Description  
this change introduces workload_image parameter to allow user in air-gapped environment to mirror the network filter workload on the private repo.

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/). 

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  