### PR TITLE
node-scenarios: Support CLOUD_TYPE='baremetal' in addition to 'bm'

### DIFF
--- a/node-scenarios/run.sh
+++ b/node-scenarios/run.sh
@@ -11,7 +11,7 @@ fi
 checks
 
 # Substitute config with environment vars defined
-if [[ "$CLOUD_TYPE" == "bm" ]]; then
+if [[ "$CLOUD_TYPE" == "bm" || "$CLOUD_TYPE" == "baremetal" ]]; then
     envsubst < /home/krkn/kraken/scenarios/baremetal_node_scenario.yaml.template > /home/krkn/kraken/scenarios/node_scenario.yaml  
 else
   envsubst < /home/krkn/kraken/scenarios/node_scenario.yaml.template > /home/krkn/kraken/scenarios/node_scenario.yaml


### PR DESCRIPTION
## Description  
Allow CLOUD_TYPE to be set to either 'bm' or 'baremetal' when
running bare metal node scenarios.

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/). 

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  