### PR TITLE
adding kubevirt node name and exit on fail

### DIFF
--- a/config.yaml.template
+++ b/config.yaml.template
@@ -73,3 +73,5 @@ kubevirt_checks:                                            # Utilizing virt che
     only_failures: $KUBE_VIRT_FAILURES                                    # Boolean of whether to show all VMI's failures and successful ssh connection (False), or only failure status' (True) 
     disconnected: $KUBE_VIRT_DISCONNECTED                                     # Boolean of how to try to connect to the VMIs; if True will use the ip_address to try ssh from within a node, if false will use the name and uses virtctl to try to connect; Default is False
     ssh_node: $KUBE_VIRT_SSH_NODE
+    node_names: $KUBE_VIRT_NODE_NAME                                          # Filter only VMI's running a specific node name
+    exit_on_failure: $KUBE_VIRT_EXIT_ON_FAIL                                     # If value is True and VMI's are failing post chaos returns failure, values can be True/False

--- a/env.sh
+++ b/env.sh
@@ -70,3 +70,5 @@ export KUBE_VIRT_NAME=${KUBE_VIRT_NAME:=""}
 export KUBE_VIRT_FAILURES=${KUBE_VIRT_FAILURES:=False}
 export KUBE_VIRT_DISCONNECTED=${KUBE_VIRT_DISCONNECTED:=False}
 export KUBE_VIRT_SSH_NODE=${KUBE_VIRT_SSH_NODE:""}
+export KUBE_VIRT_NODE_NAME=${KUBE_VIRT_NODE_NAME:""}                                     # Filter only VMI's running a specific node name
+export KUBE_VIRT_EXIT_ON_FAIL=${KUBE_VIRT_EXIT_ON_FAIL:False}


### PR DESCRIPTION
## Description  
Adding new node_name and exit_on_fail variables to the kubevirt config section

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/). 

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  