### PR TITLE
feat: add taints parameter support to krknctl input

### DIFF
--- a/node-cpu-hog/krknctl-input.json
+++ b/node-cpu-hog/krknctl-input.json
@@ -41,6 +41,15 @@
          "default":"",
          "required": "false"
      },
+     {
+        "name":"taints",
+	    "short_description":"Node Taints",
+        "description":"List of taints for which tolerations need to created. For example [\"node-role.kubernetes.io/master:NoSchedule\"]",
+        "variable":"TAINTS",
+        "type":"string",
+        "default":"[]",
+        "required": "false"
+    },
    {
         "name":"number-of-nodes",
          "short_description":"Number of nodes",

--- a/node-io-hog/krknctl-input.json
+++ b/node-io-hog/krknctl-input.json
@@ -64,6 +64,15 @@
          "default":"",
          "required": "false"
      },
+     {
+        "name":"taints",
+	    "short_description":"Node Taints",
+        "description":"List of taints for which tolerations need to created. For example [\"node-role.kubernetes.io/master:NoSchedule\"]",
+        "variable":"TAINTS",
+        "type":"string",
+        "default":"[]",
+        "required": "false"
+    },
     {
         "name":"number-of-nodes",
          "short_description":"Number of nodes",

--- a/node-memory-hog/krknctl-input.json
+++ b/node-memory-hog/krknctl-input.json
@@ -45,6 +45,15 @@
          "default":"",
          "required": "false"
      },
+     {
+        "name":"taints",
+	    "short_description":"Node Taints",
+        "description":"List of taints for which tolerations need to created. For example [\"node-role.kubernetes.io/master:NoSchedule\"]",
+        "variable":"TAINTS",
+        "type":"string",
+        "default":"[]",
+        "required": "false"
+    },
       {
         "name":"image",
          "short_description":"Hog Container image",


### PR DESCRIPTION
## Description  

[Taint config](https://krkn-chaos.dev/docs/scenarios/hog-scenarios/#config-options) is not exposed to krknctl inputs for Node [CPU Hog](https://krkn-chaos.dev/docs/scenarios/hog-scenarios/cpu-hog-scenario/cpu-hog-scenario-krknctl/) and [Memory Hog](https://krkn-chaos.dev/docs/scenarios/hog-scenarios/memory-hog-scenario/memory-hog-scenario-krknctl/) Scenarios.

## Documentation  
- [x] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/). 

## Related Documentation PR (if applicable)  
https://github.com/krkn-chaos/website/pull/184