### PR TITLE
Fix invalid default values in network-chaos krknctl-input.json

### DIFF
--- a/network-chaos/krknctl-input.json
+++ b/network-chaos/krknctl-input.json
@@ -93,7 +93,6 @@
         "description": "Dictionary with key as node name(s) and value as a list of its interfaces to test. For example: {ip-10-0-216-2.us-west-2.compute.internal: [ens5]}",
         "type": "string",
         "variable": "TARGET_NODE_AND_INTERFACE",
-        "default": "",
         "validator": "^{([a-zA-Z0-9-.]+: \\[(([A-Za-z0-9]+(,)?)+)\\](,)?)+[^,]}$",
         "validation_message": "Target node interface must be in the format: ip-10-0-216-2.us-west-2.compute.internal: [ens5]}",
         "required": "false"
@@ -104,7 +103,6 @@
         "description": "latency, loss and bandwidth are the three supported network parameters to alter for the chaos test. For example: {latency: 50ms, loss: 0.02}",
         "type": "string",
         "variable": "NETWORK_PARAMS",
-        "default": "Ingress shaping must be in the format: {bandwidth/latency/loss: 100mbit/10ms/40%}",
         "validator": "^{((latency|loss|bandwidth): [a-zA-Z0-9.]+(,)?)+[^,]}$",
         "validation_message": "Ingress shaping must be in the format: {bandwidth/latency/loss: 100mbit/10ms/40%}",
         "required": "false"


### PR DESCRIPTION
## Summary
- Remove broken `default` value from `network-params` field — the `validation_message` string was accidentally set as the default, which fails regex validation
- Remove broken `default: ""` from `target-node-interface` field — empty string fails its regex validator

## Problem

`krknctl run network-chaos` fails for both ingress and egress traffic types with:
```
Error: schema validation error on default value: Ingress shaping must be in the format: {bandwidth/latency/loss: 100mbit/10ms/40%}
```

krknctl validates all field defaults at startup (`pkg/typing/field.go:132-145`). When `default` is present (non-nil `*string`), the value is validated against the field's `validator` regex. Both fields had defaults that don't match their validators:
- `network-params`: default was the `validation_message` text, not a valid value
- `target-node-interface`: default was `""`, which doesn't match the regex

Removing the `default` key entirely makes the Go `*string` pointer `nil`, which skips default validation. This is correct for optional, scenario-specific fields.

## Test plan
- [x] Built custom image with the fix and pushed to https://quay.io/repository/rh-ee-darjain/krkn-chaos
- [x] Verified fixed image labels on quay.io manifest (no `default` key for either field)
- [x] Validated all 12 fields with krknctl's `field.Validate()` — only required `traffic-type` fails when not provided (expected)
- [x] Ran `krknctl run network-chaos --private-registry quay.io --private-registry-scenarios rh-ee-darjain/krkn-chaos` against fixed image — validation passes, environment table renders correctly

Fixes krkn-chaos/krkn-hub#316