### PR TITLE
Resiliency score

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -76,6 +76,6 @@ export KUBE_VIRT_EXIT_ON_FAIL=${KUBE_VIRT_EXIT_ON_FAIL:False}
 
 # resiliency score
 export RESILIENCY_RUN_MODE=${RESILIENCY_RUN_MODE:="standalone"}
-export RESILIENCY_RUN_MODE=$($RESILIENCY_SCORE  && echo "detailed" || echo "standalone")
-export RESILIENCY_RUN_MODE=$($DISABLE_RESILIENCY_SCORE  && echo "disabled" || echo $RESILIENCY_RUN_MODE)
+export RESILIENCY_RUN_MODE=$([ "$RESILIENCY_SCORE" = "true" ] && echo "detailed" || echo "standalone")
+export RESILIENCY_RUN_MODE=$([ "$DISABLE_RESILIENCY_SCORE" = "true" ] && echo "disabled" || echo "$RESILIENCY_RUN_MODE")
 export RESILIENCY_FILE=${RESILIENCY_FILE:="config/alerts.yaml"}


### PR DESCRIPTION
## Description  
Resiliency score is always being set to disabled 


Before 
```
 % export RESILIENCY_RUN_MODE=${RESILIENCY_RUN_MODE:="standalone"}
 % echo $RESILIENCY_RUN_MODE
standalone
% export RESILIENCY_RUN_MODE=$($RESILIENCY_SCORE  && echo "detailed" || echo "standalone")
 % export RESILIENCY_RUN_MODE=$($DISABLE_RESILIENCY_SCORE  && echo "disabled" || echo $RESILIENCY_RUN_MODE)
% echo $RESILIENCY_RUN_MODE                                                                               
disabled
```

After
 ```
% export RESILIENCY_RUN_MODE=${RESILIENCY_RUN_MODE:="standalone"}
export RESILIENCY_RUN_MODE=$([ "$RESILIENCY_SCORE" = "true" ] && echo "detailed" || echo "standalone")
export RESILIENCY_RUN_MODE=$([ "$DISABLE_RESILIENCY_SCORE" = "true" ] && echo "disabled" || echo "$RESILIENCY_RUN_MODE")
% echo $RESILIENCY_RUN_MODE                                      
standalone
% export DISABLE_RESILIENCY_SCORE=true
% export RESILIENCY_RUN_MODE=${RESILIENCY_RUN_MODE:="standalone"}
export RESILIENCY_RUN_MODE=$([ "$RESILIENCY_SCORE" = "true" ] && echo "detailed" || echo "standalone")
export RESILIENCY_RUN_MODE=$([ "$DISABLE_RESILIENCY_SCORE" = "true" ] && echo "disabled" || echo "$RESILIENCY_RUN_MODE")
% echo $RESILIENCY_RUN_MODE                             
disabled
```

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/). 

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  