### PR TITLE
Fix interfaces validator regex to allow hyphens, dots, and underscores (#320)

### DIFF
--- a/network-chaos/krknctl-input.json
+++ b/network-chaos/krknctl-input.json
@@ -72,7 +72,7 @@
         "type": "string",
         "variable": "INTERFACES",
         "default": "[]",
-        "validator": "^\\[\\]$|^\\[([a-zA-Z0-9]+(,)?)*\\[^,]]$",
+        "validator": "^\\[\\]$|^\\[([a-zA-Z0-9._-]+(,)?)*[^,]\\]$",
         "validation_message": "Interfaces must be in the format: [eth0,eth1,eth2]",
         "required": "false"
     },
@@ -93,7 +93,7 @@
         "description": "Dictionary with key as node name(s) and value as a list of its interfaces to test. For example: {ip-10-0-216-2.us-west-2.compute.internal: [ens5]}",
         "type": "string",
         "variable": "TARGET_NODE_AND_INTERFACE",
-        "validator": "^{([a-zA-Z0-9-.]+: \\[(([A-Za-z0-9]+(,)?)+)\\](,)?)+[^,]}$",
+        "validator": "^{([a-zA-Z0-9-.]+: \\[(([A-Za-z0-9._-]+(,)?)+)\\](,)?)+}$",
         "validation_message": "Target node interface must be in the format: ip-10-0-216-2.us-west-2.compute.internal: [ens5]}",
         "required": "false"
     },


### PR DESCRIPTION
## Summary

- Fixed `interfaces` validator regex in `network-chaos/krknctl-input.json` which was broken and rejected **all** non-empty interface lists, including simple ones like `[eth0]`
- Added hyphens, dots, and underscores to the character class for both `interfaces` and `target-node-interface` validators to support real-world interface names like `br-ex`, `br_int`, `eth0.1`
- Removed unnecessary `[^,]` from `TARGET_NODE_AND_INTERFACE` validator regex — it was consuming the closing `}` and causing the regex to reject all valid inputs

Fixes #320

## Root Cause

Two issues in the `interfaces` validator regex:

1. **Broken escape:** `\[^,]]` was interpreted as a literal `[` followed by `^,]` — not a negated character class. This caused the regex to reject every non-empty list.
2. **Missing characters:** The character class `[a-zA-Z0-9]` did not allow hyphens, dots, or underscores, which are common in Linux interface names (e.g. `br-ex`, `br_int`, `eth0.1`).
3. **Unnecessary `[^,]` in TARGET_NODE_AND_INTERFACE:** The `[^,]` before `}` consumed the closing brace, making the regex reject all valid inputs like `{ip-10-0-216-2.us-west-2.compute.internal: [ens5]}`.

## Validation

### INTERFACES regex
| Input | Description | Result |
|---|---|---|
| `[]` | empty list | Pass |
| `[eth0]` | simple interface | Pass |
| `[eth0,eth1]` | multiple interfaces | Pass |
| `[ens5,ens6,ans.1_any]` | dots and underscores | Pass |
| `[br-ex]` | hyphenated interface | Pass |
| `[eth0,]` | invalid: trailing comma | Rejected |

### TARGET_NODE_AND_INTERFACE regex
| Input | Description | Result |
|---|---|---|
| `{ip-10-0-216-2.us-west-2.compute.internal: [ens5]}` | single interface | Pass |
| `{ip-10-0-216-2.us-west-2.compute.internal: [ens5,ens6]}` | two interfaces | Pass |
| `{ip-10-0-216-2.us-west-2.compute.internal: [ens5,ens6,ans.1_any]}` | three interfaces | Pass |
| `{node1: [ens5],node2: [ens6]}` | two nodes | Pass |
| `{}` | invalid: empty | Rejected |
| `{node1: []}` | invalid: empty interfaces | Rejected |

### Test script
```python
import re

# TARGET_NODE_AND_INTERFACE regex (fixed - [^,] removed)
regex = r'^{([a-zA-Z0-9-.]+: \[(([A-Za-z0-9._-]+(,)?)+)\](,)?)+}$'
tests = [
    ('{ip-10-0-216-2.us-west-2.compute.internal: [ens5]}', 'single interface'),
    ('{ip-10-0-216-2.us-west-2.compute.internal: [ens5,ens6]}', 'two interfaces'),
    ('{ip-10-0-216-2.us-west-2.compute.internal: [ens5,ens6,ans.1_any]}', 'three interfaces'),
    ('{node1: [ens5],node2: [ens6]}', 'two nodes'),
    ('{}', 'empty - should fail'),
    ('{node1: []}', 'empty interfaces - should fail'),
]
for test, desc in tests:
    m = re.match(regex, test)
    print(f'{"MATCH" if m else "NO MATCH":8} | {desc}: {test}')

# INTERFACES regex (unchanged)
regex2 = r'^\[\]$|^\[([a-zA-Z0-9._-]+(,)?)*[^,]\]$'
tests2 = [
    ('[]', 'empty list'),
    ('[eth0]', 'single'),
    ('[eth0,eth1]', 'two'),
    ('[ens5,ens6,ans.1_any]', 'dots and underscores'),
    ('[eth0,]', 'trailing comma - should fail'),
]
for test, desc in tests2:
    m = re.match(regex2, test)
    print(f'{"MATCH" if m else "NO MATCH":8} | {desc}: {test}')
```