### PR TITLE
build: split docker builds into per-scenario matrix jobs

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,33 +13,53 @@ on:
 
 
 jobs:
+  list:
+    runs-on: ubuntu-latest
+    outputs:
+      scenarios: ${{ steps.list-scenarios.outputs.scenarios }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@main
+      - name: List scenarios
+        id: list-scenarios
+        run: |
+          echo "scenarios=$(docker compose config --services | jq -R -s -c 'split("\n") | map(select(length > 0))')" >> $GITHUB_OUTPUT
+
   build:
     runs-on: ubuntu-latest
+    needs: list
+    strategy:
+      matrix:
+        scenario: ${{ fromJson(needs.list.outputs.scenarios) }}
+      fail-fast: false
     steps:
-    - name: Check out code
-      uses: actions/checkout@main
-    - name: Free disk space
-      run: |
-        sudo docker image prune -af
-        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
-        df -h
-    - name: Add krknctl metadata to Dockerfiles
-      run: |
-        bash build.sh
-    - name: Build the Docker images
-      run: docker compose build --parallel
-    - name: Login in quay
-      if: ${{ github.ref == 'refs/heads/main' }}
-      run: docker login quay.io -u ${QUAY_USER} -p ${QUAY_TOKEN}
-      env:
-        QUAY_USER: ${{ secrets.QUAY_USERNAME }}
-        QUAY_TOKEN: ${{ secrets.QUAY_PASSWORD }}
-    - name: Push the Docker images
-      if: ${{ github.ref == 'refs/heads/main' }}
-      run: docker compose push
-    - name: Call repo lambda
-      if: ${{ github.ref == 'refs/heads/main'}}
-      run: |
-        curl --location --request POST '${{ secrets.LAMBDA_URL }}' --header 'Authorization: Bearer ${{ secrets.LAMBDA_TOKEN }}'
-        
-        
+      - name: Check out code
+        uses: actions/checkout@main
+      - name: Free disk space
+        run: |
+          sudo docker image prune -af
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
+          df -h
+      - name: Add krknctl metadata to Dockerfiles
+        run: |
+          bash build.sh
+      - name: Build the Docker image
+        run: docker compose build ${{ matrix.scenario }}
+      - name: Login in quay
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: docker login quay.io -u ${QUAY_USER} -p ${QUAY_TOKEN}
+        env:
+          QUAY_USER: ${{ secrets.QUAY_USERNAME }}
+          QUAY_TOKEN: ${{ secrets.QUAY_PASSWORD }}
+      - name: Push the Docker image
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: docker compose push ${{ matrix.scenario }}
+
+  notify:
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.ref == 'refs/heads/main' }}
+    steps:
+      - name: Call repo lambda
+        run: |
+          curl --location --request POST '${{ secrets.LAMBDA_URL }}' --header 'Authorization: Bearer ${{ secrets.LAMBDA_TOKEN }}'


### PR DESCRIPTION
## Summary

- Replaces single `docker compose build --parallel` job with a matrix strategy that builds each scenario in its own runner
- Adds a `list` job that dynamically generates the matrix from `docker compose config --services` — new scenarios are picked up automatically without workflow changes
- Moves the lambda notify call into a separate `notify` job that fires once after all images are pushed
- Keeps the disk cleanup step per runner as a safety measure

## Why

Builds were failing with exit code 143 (SIGTERM) after ~20 minutes due to disk exhaustion on the GitHub-hosted runner. Building all 26 images in parallel on a single runner with ~14GB disk caused Docker to hang silently mid-export, then get killed. Each runner in the matrix gets its own fresh disk, eliminating the problem.

## Test plan

- [ ] Confirm matrix jobs appear correctly (one per service) on a PR run
- [ ] Confirm `df -h` output shows sufficient free disk at build start
- [ ] Confirm all images push to quay on merge to main
- [ ] Confirm lambda is called once after all pushes complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)