### PR TITLE
build: add multi-platform amd64/arm64 image builds

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -40,20 +40,36 @@ jobs:
           sudo docker image prune -af
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
           df -h
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Add krknctl metadata to Dockerfiles
         run: |
           bash build.sh
-      - name: Build the Docker image
-        run: docker compose build ${{ matrix.scenario }}
+      - name: Get image config
+        id: config
+        run: |
+          IMAGE=$(docker compose config --format json | jq -r '.services["${{ matrix.scenario }}"].image')
+          DOCKERFILE=$(docker compose config --format json | jq -r '.services["${{ matrix.scenario }}"].build.dockerfile')
+          echo "image=$IMAGE" >> $GITHUB_OUTPUT
+          echo "dockerfile=$DOCKERFILE" >> $GITHUB_OUTPUT
       - name: Login in quay
         if: ${{ github.ref == 'refs/heads/main' }}
-        run: docker login quay.io -u ${QUAY_USER} -p ${QUAY_TOKEN}
-        env:
-          QUAY_USER: ${{ secrets.QUAY_USERNAME }}
-          QUAY_TOKEN: ${{ secrets.QUAY_PASSWORD }}
-      - name: Push the Docker image
-        if: ${{ github.ref == 'refs/heads/main' }}
-        run: docker compose push ${{ matrix.scenario }}
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Build and push multi-platform image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ steps.config.outputs.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.ref == 'refs/heads/main' }}
+          tags: ${{ steps.config.outputs.image }}
+          provenance: false
 
   notify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds QEMU and Docker Buildx setup to each matrix build job
- Switches from `docker compose build` to `docker/build-push-action` to enable multi-platform builds
- Each image is built for both `linux/amd64` and `linux/arm64` — buildx automatically creates and pushes an OCI manifest list, so users get the right architecture on pull
- On PRs both platforms are built but not pushed, validating arm64 compatibility without requiring a push
- Replaces manual `docker login` + `docker compose push` with `docker/login-action` and push via buildx

## Why

The base image `quay.io/krkn-chaos/krkn:latest` already publishes both amd64 and arm64 manifests, so all scenario images can support both architectures with no Dockerfile changes needed.

## Test plan

- [ ] Confirm both `linux/amd64` and `linux/arm64` layers appear in the quay.io manifest after merge
- [ ] Confirm PR builds complete without pushing (both platforms built and discarded)
- [ ] Pull an image on an arm64 machine and verify it runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)