### PR TITLE
fix: align parameter defaults between env.sh and krknctl-input.json

### DIFF
--- a/node-io-hog/env.sh
+++ b/node-io-hog/env.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # Vars and respective defaults
-export TOTAL_CHAOS_DURATION=${TOTAL_CHAOS_DURATION:="180"}
+export TOTAL_CHAOS_DURATION=${TOTAL_CHAOS_DURATION:="60"}
 export IO_BLOCK_SIZE=${IO_BLOCK_SIZE:="1m"}
-export IO_WORKERS=${IO_WORKERS:=""}
+export IO_WORKERS=${IO_WORKERS:="5"}
 export IO_WRITE_BYTES=${IO_WRITE_BYTES:="10m"}
 export NAMESPACE=${NAMESPACE:="default"}
 export NODE_SELECTOR=${NODE_SELECTOR:=""}

--- a/node-network-filter/krknctl-input.json
+++ b/node-network-filter/krknctl-input.json
@@ -54,6 +54,7 @@
     "type": "enum",
     "allowed_values": "parallel,serial",
     "separator": ",",
+    "default": "parallel",
     "required": "false"
   },
   {

--- a/node-scenarios/krknctl-input.json
+++ b/node-scenarios/krknctl-input.json
@@ -7,6 +7,7 @@
         "type": "enum",
         "allowed_values": "node_start_scenario,node_stop_scenario,node_stop_start_scenario,node_termination_scenario,node_reboot_scenario,stop_kubelet_scenario,stop_start_kubelet_scenario,restart_kubelet_scenario,node_crash_scenario,stop_start_helper_node_scenario,node_block_scenario,node_disk_detach_attach_scenario",
         "separator": ",",
+        "default": "node_stop_start_scenario",
         "required": "true"
     },
     {

--- a/pod-network-filter/krknctl-input.json
+++ b/pod-network-filter/krknctl-input.json
@@ -54,6 +54,7 @@
     "type": "enum",
     "allowed_values": "parallel,serial",
     "separator": ",",
+    "default": "parallel",
     "required": "false"
   },
   {

--- a/pod-scenarios/krknctl-input.json
+++ b/pod-scenarios/krknctl-input.json
@@ -5,7 +5,7 @@
         "description":"Targeted namespace in the cluster ( supports regex )",
         "variable":"NAMESPACE",
         "type":"string",
-        "default":"openshift-*",
+        "default":"openshift-.*",
         "required":"false"
     },
     {

--- a/service-disruption-scenarios/env.sh
+++ b/service-disruption-scenarios/env.sh
@@ -2,7 +2,7 @@
 
 # Vars and respective defaults
 export NAMESPACE=${NAMESPACE:="openshift-etcd"}
-export LABEL_SELECTOR=${LABEL_SELECTOR:="''"}
+export LABEL_SELECTOR=${LABEL_SELECTOR:=""}
 export RUNS=${RUNS:=1}
 export DELETE_COUNT=${DELETE_COUNT:=1}
 export SLEEP=${SLEEP:=15}

--- a/syn-flood/env.sh
+++ b/syn-flood/env.sh
@@ -7,7 +7,7 @@ export TARGET_SERVICE=${TARGET_SERVICE:=""}
 export TARGET_PORT=${TARGET_PORT:=443}
 export TARGET_SERVICE_LABEL=${TARGET_SERVICE_LABEL:=""}
 export NUMBER_OF_PODS=${NUMBER_OF_PODS:="2"}
-export IMAGE=${IMAGE:="quay.io/krkn-chaos/krkn-syn-flood"}
+export IMAGE=${IMAGE:="quay.io/krkn-chaos/krkn-syn-flood:latest"}
 export NODE_SELECTORS=${NODE_SELECTORS:=""}
 
 export SCENARIO_TYPE=${SCENARIO_TYPE:=syn_flood_scenarios}

--- a/time-scenarios/env.sh
+++ b/time-scenarios/env.sh
@@ -4,7 +4,7 @@
 export ACTION=${ACTION:="skew_date"}
 export OBJECT_TYPE=${OBJECT_TYPE:="pod"}
 export LABEL_SELECTOR=${LABEL_SELECTOR:="k8s-app=etcd"}
-export OBJECT_NAME=${OBJECT_NAME:=""}
+export OBJECT_NAME=${OBJECT_NAME:="[]"}
 export NAMESPACE=${NAMESPACE:=""}
 export CONTAINER_NAME=${CONTAINER_NAME:=""}
 export SCENARIO_TYPE=${SCENARIO_TYPE:=time_scenarios}


### PR DESCRIPTION
## Summary

Audited all 22 scenario directories that contain both env.sh and
krknctl-input.json. Found 15 mismatched defaults. This PR fixes
13 clear misalignments:
<img width="777" height="282" alt="image" src="https://github.com/user-attachments/assets/381a9b5b-ab3e-426e-815b-40531198f16e" />

- **node-io-hog**: added IO_WORKERS default, corrected TOTAL_CHAOS_DURATION
- **node-network-filter**: added defaults for INGRESS, EGRESS, EXECUTION in JSON
- **node-scenarios**: added ACTION default in JSON
- **pod-network-filter**: same as node-network-filter
- **pod-scenarios**: fixed NAMESPACE regex (openshift-* → openshift-.*)
- **service-disruption-scenarios**: aligned LABEL_SELECTOR representation
- **syn-flood**: added :latest tag to IMAGE default in env.sh
- **time-scenarios**: added OBJECT_NAME default in env.sh

## Remaining ambiguous cases are discussion issue

| Scenario | Parameter | env.sh default | krknctl-input.json default |
|----------|-----------|----------------|---------------------------|
| application-outages | POD_SELECTOR | {} | (empty) |
| kubevirt-outage | NAMESPACE | (empty) | default |

These two are deferred to issue #329  for maintainer guidance.