### PR TITLE
fix: trigger kubectl validation in common_run.sh

### DIFF
--- a/common_run.sh
+++ b/common_run.sh
@@ -40,4 +40,5 @@ check_cluster_version() {
 
 checks() {
   check_oc
+  check_kubectl
 }


### PR DESCRIPTION
#331
branch :'fix/unused-validation-check'
hi @paigerube14 @rh-rahulshetty @ddjain 
The common_run.sh script defines a check_kubectl() validation function, but it is never called inside the main checks() function. As a result, environments without kubectl pass the initial validation and fail later during execution.

This validation is required to ensure a fail-fast behavior and verify that all required Kubernetes dependencies are available before scenarios start running.
before :

<img width="1300" height="219" alt="Image" src="https://github.com/user-attachments/assets/888a3dbd-b3e6-446a-ae4a-460e95062929" />

Proposed Fix :
```bash
checks() {
  check_oc
  check_kubectl
}