### PR TITLE
Fix kubeconfig mount path in README.md instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For example:
 `docker run $(./get_docker_params.sh) --net=host -v <path-to-kube-config>:/home/krkn/.kube/config:Z -d quay.io/redhat-chaos/krkn-hub:power-outages`
 
 **TIP**: Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands:
-```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host -v ~kubeconfig:/home/krkn/.kube/config:Z -d quay.io/krkn-chaos/krkn-hub:<scenario>```
+```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host -v ~/kubeconfig:/home/krkn/.kube/config:Z -d quay.io/krkn-chaos/krkn-hub:<scenario>```
 
 ### Adding New Scenarios/Testing Changes
 


### PR DESCRIPTION
#335 
hi @paigerube14  @ddjain  @rh-rahulshetty 
Type of change
☑ Bug fix
☐ Refactor
☐ New feature
☐ Optimization

## Description

The documentation currently uses the following volume mount path:

```bash
-v ~kubeconfig:/home/krkn/.kube/config:Z
```

In Unix-like shells, `~kubeconfig` is interpreted as the home directory of a user named `kubeconfig`, rather than a file inside the current user's home directory. Since such a user typically does not exist, the path expansion may fail and result in an invalid mount path.

This PR updates the command to use:

```bash
-v ~/kubeconfig:/home/krkn/.kube/config:Z
```

which correctly references the kubeconfig file generated in the previous step:

```bash
kubectl config view --flatten > ~/kubeconfig
```

This makes the documentation consistent and prevents potential volume mount issues caused by incorrect shell path expansion.

## Documentation

☑ Is documentation needed for this update?

## Checklist before requesting a review

☑ I have performed a self-review of my changes
☑ Changes are consistent with the project's documentation style

## Testing performed

Verified shell path expansion behavior for both:

```bash
~kubeconfig
```

and

```bash
~/kubeconfig
```

Confirmed that `~/kubeconfig` correctly resolves to the current user's home directory path and matches the file generated in the previous documentation step.
