### PR TITLE
build: split docker builds into dual-repository strategy

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           echo "scenarios=$(docker compose config --services | jq -R -s -c 'split("\n") | map(select(length > 0))')" >> $GITHUB_OUTPUT
 
-  build:
+  build-amd64:
     runs-on: ubuntu-latest
     needs: list
     strategy:
@@ -72,9 +72,65 @@ jobs:
           tags: ${{ steps.config.outputs.image }}
           provenance: false
 
+  build-multiarch:
+    runs-on: ubuntu-latest
+    needs: list
+    strategy:
+      matrix:
+        scenario: ${{ fromJson(needs.list.outputs.scenarios) }}
+      fail-fast: false
+    steps:
+      - name: Check out code
+        uses: actions/checkout@main
+      - name: Free disk space
+        run: |
+          sudo docker image prune -af
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
+          df -h
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Add krknctl metadata to Dockerfiles
+        run: |
+          bash build.sh
+      - name: Get image config
+        id: config
+        run: |
+          IMAGE=$(docker compose config --format json | jq -r '.services["${{ matrix.scenario }}"].image')
+          DOCKERFILE=$(docker compose config --format json | jq -r '.services["${{ matrix.scenario }}"].build.dockerfile')
+
+          # Transform krkn-hub to krkn-hub-multiarch for this job
+          # Skip cerberus images (they stay amd64-only)
+          if echo "$IMAGE" | grep -q "krkn-hub:"; then
+            MULTIARCH_IMAGE=$(echo "$IMAGE" | sed 's|/krkn-hub:|/krkn-hub-multiarch:|g')
+          else
+            MULTIARCH_IMAGE=""
+          fi
+
+          echo "image=$MULTIARCH_IMAGE" >> $GITHUB_OUTPUT
+          echo "dockerfile=$DOCKERFILE" >> $GITHUB_OUTPUT
+      - name: Login in quay
+        if: ${{ github.ref == 'refs/heads/main' && steps.config.outputs.image != '' }}
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Build and push multi-platform image
+        if: ${{ steps.config.outputs.image != '' }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ steps.config.outputs.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.ref == 'refs/heads/main' }}
+          tags: ${{ steps.config.outputs.image }}
+          provenance: false
+
   notify:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build-amd64, build-multiarch]
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - name: Call repo lambda


### PR DESCRIPTION
Introduces separate build jobs to push images to two repositories:
- build-amd64: pushes amd64-only images to krkn-hub
- build-multiarch: pushes amd64+arm64 images to krkn-hub-multiarch

This allows consumers to choose between single-arch (no manifest list) and multi-arch (automatic manifest) images on the same tag names.

## Description  
<!-- Provide a brief description of the changes made in this PR. -->  

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/). 

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  