### PR TITLE
feat: add storage throttle scenario support in krkn-hub

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 SCENARIOS=( application-outages container-scenarios network-chaos node-cpu-hog node-io-hog \
 node-memory-hog node-scenarios node-scenarios-bm pod-network-chaos pod-scenarios power-outages pvc-scenario \
 service-disruption-scenarios service-hijacking syn-flood time-scenarios zone-outages node-network-filter pod-network-filter kubevirt-outage node-interface-down http-load rollback vmi-network-filter vmi-network \
-dummy-scenario)
+dummy-scenario storage-throttle)
 for i in "${SCENARIOS[@]}"; do
     export KRKNCTL_INPUT=$(cat $i/krknctl-input.json|tr -d "\n")
     envsubst < $i/Dockerfile.template > $i/Dockerfile

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -89,6 +89,11 @@ services:
         context: ./
         dockerfile: ./pvc-scenario/Dockerfile
       image: quay.io/krkn-chaos/krkn-hub:pvc-scenarios
+    storage-throttle:
+      build:
+        context: ./
+        dockerfile: ./storage-throttle/Dockerfile
+      image: quay.io/krkn-chaos/krkn-hub:storage-throttle
     network-chaos:
       build:
         context: ./

--- a/docs/storage-throttle.md
+++ b/docs/storage-throttle.md
@@ -1,0 +1,5 @@
+### Storage Throttle Scenario
+This scenario applies storage I/O limits (IOPS and/or bandwidth) on a PVC-backed workload by using Linux cgroup controls through a privileged helper pod on the target node.
+
+For setup, run steps, and supported parameters, refer to the upstream documentation:
+[Storage Throttle Scenario](https://krkn-chaos.dev/docs/scenarios/storage-throttle/#tab-krkn-hub)

--- a/storage-throttle/Dockerfile.template
+++ b/storage-throttle/Dockerfile.template
@@ -1,0 +1,24 @@
+# Dockerfile for kraken
+
+FROM quay.io/krkn-chaos/krkn:latest
+
+ENV KUBECONFIG /home/krkn/.kube/config
+
+# Copy configurations
+COPY config.yaml.template /home/krkn/kraken/config/config.yaml.template
+COPY metrics_config.yaml.template /home/krkn/kraken/config/kube_burner.yaml.template
+COPY storage-throttle/env.sh /home/krkn/env.sh
+COPY env.sh /home/krkn/main_env.sh
+COPY storage-throttle/run.sh /home/krkn/run.sh
+COPY common_run.sh /home/krkn/common_run.sh
+COPY storage-throttle/storage_throttle.yaml.template /home/krkn/kraken/scenarios/storage_throttle.yaml.template
+
+LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.has_rollback="true"
+LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
+LABEL krknctl.title="Storage I/O Throttle"
+LABEL krknctl.description="This scenario applies read/write IOPS and bandwidth throttling to a pod volume using cgroups v1/v2 through a privileged helper pod."
+
+LABEL krknctl.input_fields='$KRKNCTL_INPUT'
+
+ENTRYPOINT /home/krkn/kraken/containers/setup-ssh.sh && /home/krkn/run.sh

--- a/storage-throttle/README.md
+++ b/storage-throttle/README.md
@@ -1,0 +1,3 @@
+# Storage Throttle Scenario Docs
+
+See [doc](https://krkn-chaos.dev/docs/scenarios/storage-throttle/#tab-krkn-hub) for how to run and all the variables listed.

--- a/storage-throttle/env.sh
+++ b/storage-throttle/env.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Vars and respective defaults
+export PVC_NAME=${PVC_NAME:=""}
+export POD_NAME=${POD_NAME:=""}
+export NAMESPACE=${NAMESPACE:="default"}
+export MOUNT_PATH=${MOUNT_PATH:=""}
+export THROTTLE_TYPE=${THROTTLE_TYPE:="bandwidth"}
+export READ_IOPS=${READ_IOPS:="100"}
+export WRITE_IOPS=${WRITE_IOPS:="50"}
+export READ_BPS=${READ_BPS:="1Mi"}
+export WRITE_BPS=${WRITE_BPS:="512Ki"}
+export DURATION=${DURATION:="1m"}
+export IMAGE=${IMAGE:="quay.io/krkn-chaos/krkn:tools"}
+export SCENARIO_TYPE=${SCENARIO_TYPE:=storage_throttle_scenarios}
+export SCENARIO_FILE=${SCENARIO_FILE:=scenarios/storage_throttle.yaml}

--- a/storage-throttle/krknctl-input.json
+++ b/storage-throttle/krknctl-input.json
@@ -1,0 +1,105 @@
+[
+  {
+    "name": "pvc-name",
+    "short_description": "PVC name",
+    "description": "Target PVC name. If set, pod_name is auto-resolved from PVC",
+    "variable": "PVC_NAME",
+    "type": "string",
+    "default": "",
+    "required": "false"
+  },
+  {
+    "name": "pod-name",
+    "short_description": "Pod name",
+    "description": "Target pod name. Ignored if PVC_NAME is set",
+    "variable": "POD_NAME",
+    "type": "string",
+    "default": "",
+    "required": "false"
+  },
+  {
+    "name": "namespace",
+    "short_description": "Namespace",
+    "description": "Namespace of the target pod/PVC",
+    "variable": "NAMESPACE",
+    "type": "string",
+    "default": "default",
+    "required": "true"
+  },
+  {
+    "name": "mount-path",
+    "short_description": "Mount path",
+    "description": "Specific mount path to throttle (optional)",
+    "variable": "MOUNT_PATH",
+    "type": "string",
+    "validator": "^$|^/[a-zA-Z0-9._/\\-]+$",
+    "validation_message": "Mount path must be an absolute path like /data",
+    "default": "",
+    "required": "false"
+  },
+  {
+    "name": "throttle-type",
+    "short_description": "Throttle mode",
+    "description": "Throttle mode to apply",
+    "variable": "THROTTLE_TYPE",
+    "type": "enum",
+    "allowed_values": "bandwidth,iops,both",
+    "separator": ",",
+    "default": "bandwidth",
+    "required": "false"
+  },
+  {
+    "name": "read-iops",
+    "short_description": "Read IOPS",
+    "description": "Maximum read IOPS (used for iops/both)",
+    "variable": "READ_IOPS",
+    "type": "number",
+    "default": "100",
+    "required": "false"
+  },
+  {
+    "name": "write-iops",
+    "short_description": "Write IOPS",
+    "description": "Maximum write IOPS (used for iops/both)",
+    "variable": "WRITE_IOPS",
+    "type": "number",
+    "default": "50",
+    "required": "false"
+  },
+  {
+    "name": "read-bps",
+    "short_description": "Read bandwidth",
+    "description": "Maximum read bytes/sec (supports values like 1Mi, 512Ki, 1000000)",
+    "variable": "READ_BPS",
+    "type": "string",
+    "default": "1Mi",
+    "required": "false"
+  },
+  {
+    "name": "write-bps",
+    "short_description": "Write bandwidth",
+    "description": "Maximum write bytes/sec (supports values like 512Ki, 1Mi, 500000)",
+    "variable": "WRITE_BPS",
+    "type": "string",
+    "default": "512Ki",
+    "required": "false"
+  },
+  {
+    "name": "duration",
+    "short_description": "Duration",
+    "description": "Duration to hold throttling (supports values like 30s, 1m, 120)",
+    "variable": "DURATION",
+    "type": "string",
+    "default": "1m",
+    "required": "false"
+  },
+  {
+    "name": "image",
+    "short_description": "Helper pod image",
+    "description": "Image used for privileged helper pod that writes cgroup values",
+    "variable": "IMAGE",
+    "type": "string",
+    "default": "quay.io/krkn-chaos/krkn:tools",
+    "required": "false"
+  }
+]

--- a/storage-throttle/run.sh
+++ b/storage-throttle/run.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Source env.sh to read all the vars
+source /home/krkn/main_env.sh
+source /home/krkn/env.sh
+source /home/krkn/common_run.sh
+
+if [[ $KRKN_DEBUG == "True" ]];then
+  set -ex
+fi
+
+checks
+
+# Substitute config with environment vars defined
+envsubst < /home/krkn/kraken/scenarios/storage_throttle.yaml.template > /home/krkn/kraken/scenarios/storage_throttle.yaml
+envsubst < /home/krkn/kraken/config/config.yaml.template > /home/krkn/kraken/config/storage_throttle_config.yaml
+
+# Run Kraken
+cd /home/krkn/kraken
+extra_var=""
+if [[ $KRKN_DEBUG == "True" ]];then
+  cat config/storage_throttle_config.yaml
+  cat scenarios/storage_throttle.yaml
+  extra_var="--debug True"
+fi
+
+python3.11 run_kraken.py --config=config/storage_throttle_config.yaml $extra_var

--- a/storage-throttle/storage_throttle.yaml.template
+++ b/storage-throttle/storage_throttle.yaml.template
@@ -1,0 +1,12 @@
+storage_throttle_scenario:
+  pvc_name: $PVC_NAME            # Target PVC name. If set, pod_name is auto-resolved from PVC.
+  pod_name: $POD_NAME            # Target pod name. Ignored if pvc_name is set.
+  namespace: $NAMESPACE          # Namespace of the target PVC/pod
+  mount_path: $MOUNT_PATH        # Specific mount path to throttle. If empty, first PVC mount is used.
+  throttle_type: $THROTTLE_TYPE  # "iops", "bandwidth", or "both"
+  read_iops: $READ_IOPS          # Max read IOPS (used when throttle_type is "iops" or "both")
+  write_iops: $WRITE_IOPS        # Max write IOPS (used when throttle_type is "iops" or "both")
+  read_bps: $READ_BPS            # Max read bytes/sec (used when throttle_type is "bandwidth" or "both")
+  write_bps: $WRITE_BPS          # Max write bytes/sec (used when throttle_type is "bandwidth" or "both")
+  duration: $DURATION            # How long to hold the throttle (supports suffixes: s, m, h)
+  image: $IMAGE                  # Image used for privileged helper pod on target node


### PR DESCRIPTION
## Description
Adds storage throttle scenario support in krkn-hub.

Changes included:
- Added new scenario directory storage-throttle with:
  - env.sh
  - run.sh
  - storage_throttle.yaml.template
  - krknctl-input.json
  - Dockerfile.template
  - README.md
- Added docs/storage-throttle.md
- Updated build.sh to include storage-throttle in scenario generation
- Updated docker-compose.yaml to include storage-throttle image build entry

How tested:
- Ran build.sh
- Ran docker compose build storage-throttle
- Ran docker run for storage-throttle with demo PVC, namespace, mount path, IOPS, bandwidth, and duration values

## Documentation
- [x] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)
https://github.com/krkn-chaos/website/pull/410