### PR TITLE
fix(network-chaos): allow quoted loss values in network-params and egress validators

### DIFF
--- a/network-chaos/krknctl-input.json
+++ b/network-chaos/krknctl-input.json
@@ -83,7 +83,7 @@
         "type": "string",
         "variable": "EGRESS",
         "default": "{bandwidth: 100mbit}",
-        "validator": "^{((latency|loss|bandwidth): '?[a-zA-Z0-9.]+'?(,)?)+[^,]}$",
+        "validator": "^{(latency|loss|bandwidth): '?[a-zA-Z0-9.]+'?(,\\s*(latency|loss|bandwidth): '?[a-zA-Z0-9.]+'?)*}$",
         "validation_message": "Egress shaping must be in the format: {bandwidth/latency/loss: 100mbit/10ms/0.02}",
         "required": "false"
     },
@@ -103,7 +103,7 @@
         "description": "latency, loss and bandwidth are the three supported network parameters to alter for the chaos test. For example: {latency: 50ms, loss: '0.02'}",
         "type": "string",
         "variable": "NETWORK_PARAMS",
-        "validator": "^{((latency|loss|bandwidth): '?[a-zA-Z0-9.]+'?(,)?)+[^,]}$",
+        "validator": "^{(latency|loss|bandwidth): '?[a-zA-Z0-9.]+'?(,\\s*(latency|loss|bandwidth): '?[a-zA-Z0-9.]+'?)*}$",
         "validation_message": "Ingress shaping must be in the format: {bandwidth/latency/loss: 100mbit/10ms/'0.02'}",
         "required": "false"
     },

--- a/network-chaos/krknctl-input.json
+++ b/network-chaos/krknctl-input.json
@@ -83,8 +83,8 @@
         "type": "string",
         "variable": "EGRESS",
         "default": "{bandwidth: 100mbit}",
-        "validator": "^{((latency|loss|bandwidth): [a-zA-Z0-9.]+(,)?)+[^,]}$",
-        "validation_message": "Egress shaping must be in the format: {bandwidth/latency/loss: 100mbit/10ms/40%}",
+        "validator": "^{((latency|loss|bandwidth): '?[a-zA-Z0-9.]+'?(,)?)+[^,]}$",
+        "validation_message": "Egress shaping must be in the format: {bandwidth/latency/loss: 100mbit/10ms/0.02}",
         "required": "false"
     },
     {
@@ -100,11 +100,11 @@
     {
         "name": "network-params",
         "short_description": "Network Params [*Ingress only*]",
-        "description": "latency, loss and bandwidth are the three supported network parameters to alter for the chaos test. For example: {latency: 50ms, loss: 0.02}",
+        "description": "latency, loss and bandwidth are the three supported network parameters to alter for the chaos test. For example: {latency: 50ms, loss: '0.02'}",
         "type": "string",
         "variable": "NETWORK_PARAMS",
-        "validator": "^{((latency|loss|bandwidth): [a-zA-Z0-9.]+(,)?)+[^,]}$",
-        "validation_message": "Ingress shaping must be in the format: {bandwidth/latency/loss: 100mbit/10ms/40%}",
+        "validator": "^{((latency|loss|bandwidth): '?[a-zA-Z0-9.]+'?(,)?)+[^,]}$",
+        "validation_message": "Ingress shaping must be in the format: {bandwidth/latency/loss: 100mbit/10ms/'0.02'}",
         "required": "false"
     },
     {


### PR DESCRIPTION
## Summary

- The `network-params` and `egress` validators in `krknctl-input.json` used the regex `[a-zA-Z0-9.]+` for values, which rejects single-quoted loss values like `'0.02'`
- This forces users to pass loss unquoted (`loss: 0.02`), but YAML then parses `0.02` as a **float**
- krkn's ingress plugin (`ingress_shaping.py`) declares `network_params` as `Dict[str, str]` via the arcaflow SDK, which strictly rejects float values, causing the scenario to fail with:
  ```
  Validation failed for 'NetworkScenarioConfig -> network_params -> loss -> value': Must be a string, <class 'float'> given
  ```
- The krkn scenario template itself documents this requirement: [`network_chaos_ingress.yml`](https://github.com/krkn-chaos/krkn/blob/main/scenarios/openshift/network_chaos_ingress.yml)
  ```yaml
  loss: <fraction>  # It has to be enclosed in quotes to treat it as a string. For example, '0.02' (not 0.02)
  ```

## Fix

Updated the regex from:
```
^{((latency|loss|bandwidth): [a-zA-Z0-9.]+(,)?)+[^,]}$
```
to:
```
^{((latency|loss|bandwidth): '?[a-zA-Z0-9.]+'?(,)?)+[^,]}$
```

This allows optional single quotes around values so `loss: '0.02'` passes validation and YAML correctly parses it as a string.

Also corrects the `validation_message` examples: loss is a decimal fraction (0–1), not a percentage — the previous `40%` example was incorrect and would not pass the regex itself.

## Test plan

- [x] Regex tested against valid and invalid inputs — quoted and unquoted values pass, trailing commas and unknown keys fail
- [x] `{latency: 50ms, loss: '0.02', bandwidth: 100mbit}` now accepted by krknctl
- [x] Backward compatible — unquoted values like `loss: 0.02` still pass the regex

🤖 Generated with [Claude Code](https://claude.com/claude-code)