### PR TITLE
feat: add baremetal standalone chaos containers

### DIFF
--- a/baremetal-cpu-hog/Dockerfile.template
+++ b/baremetal-cpu-hog/Dockerfile.template
@@ -1,0 +1,13 @@
+FROM quay.io/krkn-chaos/krkn:latest
+
+# Copy configurations
+COPY baremetal-cpu-hog/env.sh /home/krkn/env.sh
+COPY env.sh /home/krkn/main_env.sh
+COPY baremetal-cpu-hog/run.sh /home/krkn/run.sh
+
+LABEL krknctl.title="Baremetal CPU Hog"
+LABEL krknctl.description="CPU stress test on baremetal/standalone hosts via SSH using stress-ng. Targets hosts directly without requiring Kubernetes."
+
+LABEL krknctl.input_fields='$KRKNCTL_INPUT'
+
+ENTRYPOINT /home/krkn/run.sh

--- a/baremetal-cpu-hog/env.sh
+++ b/baremetal-cpu-hog/env.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Vars and respective defaults
+export TARGETS=${TARGETS:=""}
+export SSH_USER=${SSH_USER:="root"}
+export SSH_PRIVATE_KEY=${SSH_PRIVATE_KEY:="/home/krkn/.ssh/id_rsa"}
+export SSH_PORT=${SSH_PORT:="22"}
+export NODE_CPU_CORE=${NODE_CPU_CORE:="0"}
+export NODE_CPU_PERCENTAGE=${NODE_CPU_PERCENTAGE:="50"}
+export TOTAL_CHAOS_DURATION=${TOTAL_CHAOS_DURATION:="60"}
+
+export SCENARIO_TYPE=${SCENARIO_TYPE:=hog_scenarios}
+export SCENARIO_FILE=${SCENARIO_FILE:=scenarios/standalone/baremetal-cpu-hog.yml}

--- a/baremetal-cpu-hog/krknctl-input.json
+++ b/baremetal-cpu-hog/krknctl-input.json
@@ -1,0 +1,61 @@
+[
+    {
+        "name": "targets",
+        "short_description": "Target Hosts",
+        "description": "Comma-separated list of target host IPs or hostnames to stress (e.g., 192.168.1.100,192.168.1.101)",
+        "variable": "TARGETS",
+        "type": "string",
+        "required": "true"
+    },
+    {
+        "name": "ssh-user",
+        "short_description": "SSH User",
+        "description": "SSH username for connecting to target hosts",
+        "variable": "SSH_USER",
+        "type": "string",
+        "default": "root",
+        "required": "false"
+    },
+    {
+        "name": "ssh-private-key",
+        "short_description": "SSH Private Key Path",
+        "description": "Path to SSH private key file inside the container",
+        "variable": "SSH_PRIVATE_KEY",
+        "type": "string",
+        "default": "/home/krkn/.ssh/id_rsa",
+        "required": "false"
+    },
+    {
+        "name": "ssh-port",
+        "short_description": "SSH Port",
+        "description": "SSH port for connecting to target hosts",
+        "variable": "SSH_PORT",
+        "type": "number",
+        "default": "22",
+        "required": "false"
+    },
+    {
+        "name": "cpu-cores",
+        "short_description": "CPU Cores",
+        "description": "Number of CPU cores (workers) to stress. 0 means all available cores.",
+        "variable": "NODE_CPU_CORE",
+        "type": "number",
+        "default": "0"
+    },
+    {
+        "name": "cpu-percentage",
+        "short_description": "CPU Percentage",
+        "description": "Percentage of CPU to consume per core",
+        "variable": "NODE_CPU_PERCENTAGE",
+        "type": "number",
+        "default": "50"
+    },
+    {
+        "name": "chaos-duration",
+        "short_description": "Chaos Duration",
+        "description": "Duration of CPU stress in seconds",
+        "variable": "TOTAL_CHAOS_DURATION",
+        "type": "number",
+        "default": "60"
+    }
+]

--- a/baremetal-cpu-hog/run.sh
+++ b/baremetal-cpu-hog/run.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+ROOT_FOLDER="/home/krkn"
+KRAKEN_FOLDER="$ROOT_FOLDER/kraken"
+SCENARIO_FOLDER="$KRAKEN_FOLDER/scenarios/standalone"
+
+# Source env.sh to read all the vars
+source $ROOT_FOLDER/main_env.sh
+source $ROOT_FOLDER/env.sh
+
+if [[ $KRKN_DEBUG == "True" ]]; then
+  set -ex
+fi
+
+mkdir -p $SCENARIO_FOLDER
+
+# Validate inputs to prevent injection
+validate_input() {
+  local name="$1" value="$2" pattern="$3"
+  if [[ ! "$value" =~ $pattern ]]; then
+    echo "ERROR: Invalid $name: $value" >&2
+    exit 1
+  fi
+}
+
+validate_input "SSH_USER" "$SSH_USER" '^[a-zA-Z0-9_.-]+$'
+
+# Generate scenario YAML
+SCENARIO_FILE_PATH="$KRAKEN_FOLDER/$SCENARIO_FILE"
+{
+  echo "hog-type: cpu"
+  echo "targets:"
+  IFS=',' read -ra TARGET_ARRAY <<< "$TARGETS"
+  for target in "${TARGET_ARRAY[@]}"; do
+    target=$(echo "$target" | xargs)
+    if [[ -n "$target" ]]; then
+      validate_input "TARGET" "$target" '^[a-zA-Z0-9._:-]+$'
+      echo "  - ${target}"
+    fi
+  done
+  echo "ssh_user: ${SSH_USER}"
+  echo "ssh_private_key: ${SSH_PRIVATE_KEY}"
+  echo "ssh_port: ${SSH_PORT:-22}"
+  echo "node-selector: \"\""
+  echo "duration: ${TOTAL_CHAOS_DURATION}"
+  echo "workers: ${NODE_CPU_CORE}"
+  echo "cpu-load-percentage: ${NODE_CPU_PERCENTAGE}"
+} > "$SCENARIO_FILE_PATH"
+
+# Generate standalone config
+cat > $KRAKEN_FOLDER/config/baremetal-cpu-hog-config.yaml <<EOF
+kraken:
+    execution_mode: standalone
+    kubeconfig_path:
+    exit_on_failure: False
+    publish_kraken_status: False
+    signal_state: RUN
+    signal_address: 0.0.0.0
+    port: 8081
+    chaos_scenarios:
+        - $SCENARIO_TYPE:
+            - $SCENARIO_FILE
+
+tunings:
+    wait_duration: ${WAIT_DURATION:-10}
+    iterations: ${ITERATIONS:-1}
+    daemon_mode: False
+
+performance_monitoring:
+    prometheus_url:
+    prometheus_bearer_token:
+    uuid:
+    enable_alerts: False
+    enable_metrics: False
+    alert_profile:
+    metrics_profile:
+    check_critical_alerts: False
+
+cerberus:
+    cerberus_enabled: False
+    cerberus_url:
+
+elastic:
+    enable_elastic: False
+
+telemetry:
+    enabled: False
+
+resiliency:
+    resiliency_run_mode: disabled
+EOF
+
+if [[ $KRKN_DEBUG == "True" ]]; then
+  cat $SCENARIO_FILE_PATH
+  cat $KRAKEN_FOLDER/config/baremetal-cpu-hog-config.yaml
+fi
+
+# Run Kraken
+cd $KRAKEN_FOLDER
+extra_var=""
+if [[ $KRKN_DEBUG == "True" ]]; then
+  extra_var="--debug True"
+fi
+
+python3.11 run_kraken.py --config=config/baremetal-cpu-hog-config.yaml $extra_var

--- a/baremetal-io-hog/Dockerfile.template
+++ b/baremetal-io-hog/Dockerfile.template
@@ -1,0 +1,13 @@
+FROM quay.io/krkn-chaos/krkn:latest
+
+# Copy configurations
+COPY baremetal-io-hog/env.sh /home/krkn/env.sh
+COPY env.sh /home/krkn/main_env.sh
+COPY baremetal-io-hog/run.sh /home/krkn/run.sh
+
+LABEL krknctl.title="Baremetal I/O Hog"
+LABEL krknctl.description="I/O stress test on baremetal/standalone hosts via SSH using stress-ng. Targets hosts directly without requiring Kubernetes."
+
+LABEL krknctl.input_fields='$KRKNCTL_INPUT'
+
+ENTRYPOINT /home/krkn/run.sh

--- a/baremetal-io-hog/env.sh
+++ b/baremetal-io-hog/env.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Vars and respective defaults
+export TARGETS=${TARGETS:=""}
+export SSH_USER=${SSH_USER:="root"}
+export SSH_PRIVATE_KEY=${SSH_PRIVATE_KEY:="/home/krkn/.ssh/id_rsa"}
+export SSH_PORT=${SSH_PORT:="22"}
+export IO_BLOCK_SIZE=${IO_BLOCK_SIZE:="1m"}
+export IO_WORKERS=${IO_WORKERS:="5"}
+export IO_WRITE_BYTES=${IO_WRITE_BYTES:="10m"}
+export TOTAL_CHAOS_DURATION=${TOTAL_CHAOS_DURATION:="60"}
+export FILL_PATH=${FILL_PATH:="/tmp"}
+export FILL_PERCENTAGE=${FILL_PERCENTAGE:="90"}
+
+export SCENARIO_TYPE=${SCENARIO_TYPE:=hog_scenarios}
+export SCENARIO_FILE=${SCENARIO_FILE:=scenarios/standalone/baremetal-io-hog.yml}

--- a/baremetal-io-hog/krknctl-input.json
+++ b/baremetal-io-hog/krknctl-input.json
@@ -1,0 +1,75 @@
+[
+    {
+        "name": "targets",
+        "short_description": "Target Hosts",
+        "description": "Comma-separated list of target host IPs or hostnames to stress (e.g., 192.168.1.100,192.168.1.101)",
+        "variable": "TARGETS",
+        "type": "string",
+        "required": "true"
+    },
+    {
+        "name": "ssh-user",
+        "short_description": "SSH User",
+        "description": "SSH username for connecting to target hosts",
+        "variable": "SSH_USER",
+        "type": "string",
+        "default": "root",
+        "required": "false"
+    },
+    {
+        "name": "ssh-private-key",
+        "short_description": "SSH Private Key Path",
+        "description": "Path to SSH private key file inside the container",
+        "variable": "SSH_PRIVATE_KEY",
+        "type": "string",
+        "default": "/home/krkn/.ssh/id_rsa",
+        "required": "false"
+    },
+    {
+        "name": "ssh-port",
+        "short_description": "SSH Port",
+        "description": "SSH port for connecting to target hosts",
+        "variable": "SSH_PORT",
+        "type": "number",
+        "default": "22",
+        "required": "false"
+    },
+    {
+        "name": "io-block-size",
+        "short_description": "I/O Block Size",
+        "description": "Size of each write in bytes (allowed suffixes: b, k, m)",
+        "variable": "IO_BLOCK_SIZE",
+        "type": "string",
+        "validator": "^[0-9]+[bkm]$",
+        "validation_message": "I/O Block size must be in the format: 4m (allowed suffixes are b, k, m)",
+        "default": "1m",
+        "required": "false"
+    },
+    {
+        "name": "io-workers",
+        "short_description": "I/O Workers",
+        "description": "Number of stress-ng I/O worker instances",
+        "variable": "IO_WORKERS",
+        "type": "number",
+        "default": "5",
+        "required": "false"
+    },
+    {
+        "name": "io-write-bytes",
+        "short_description": "I/O Write Bytes",
+        "description": "Bytes written per worker (e.g., 10m, 1g, 50%)",
+        "variable": "IO_WRITE_BYTES",
+        "type": "string",
+        "validator": "^[0-9]+[%bkmg]$",
+        "validation_message": "I/O write bytes must be in the format: 4m or 45% (allowed suffixes are %, b, k, m, g)",
+        "default": "10m"
+    },
+    {
+        "name": "chaos-duration",
+        "short_description": "Chaos Duration",
+        "description": "Duration of I/O stress in seconds",
+        "variable": "TOTAL_CHAOS_DURATION",
+        "type": "number",
+        "default": "60"
+    }
+]

--- a/baremetal-io-hog/run.sh
+++ b/baremetal-io-hog/run.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+ROOT_FOLDER="/home/krkn"
+KRAKEN_FOLDER="$ROOT_FOLDER/kraken"
+SCENARIO_FOLDER="$KRAKEN_FOLDER/scenarios/standalone"
+
+# Source env.sh to read all the vars
+source $ROOT_FOLDER/main_env.sh
+source $ROOT_FOLDER/env.sh
+
+if [[ $KRKN_DEBUG == "True" ]]; then
+  set -ex
+fi
+
+mkdir -p $SCENARIO_FOLDER
+
+# Validate inputs to prevent injection
+validate_input() {
+  local name="$1" value="$2" pattern="$3"
+  if [[ ! "$value" =~ $pattern ]]; then
+    echo "ERROR: Invalid $name: $value" >&2
+    exit 1
+  fi
+}
+
+validate_input "SSH_USER" "$SSH_USER" '^[a-zA-Z0-9_.-]+$'
+
+# Generate scenario YAML
+SCENARIO_FILE_PATH="$KRAKEN_FOLDER/$SCENARIO_FILE"
+{
+  echo "hog-type: io"
+  echo "targets:"
+  IFS=',' read -ra TARGET_ARRAY <<< "$TARGETS"
+  for target in "${TARGET_ARRAY[@]}"; do
+    target=$(echo "$target" | xargs)
+    if [[ -n "$target" ]]; then
+      validate_input "TARGET" "$target" '^[a-zA-Z0-9._:-]+$'
+      echo "  - ${target}"
+    fi
+  done
+  echo "ssh_user: ${SSH_USER}"
+  echo "ssh_private_key: ${SSH_PRIVATE_KEY}"
+  echo "ssh_port: ${SSH_PORT:-22}"
+  echo "node-selector: \"\""
+  echo "duration: ${TOTAL_CHAOS_DURATION}"
+  echo "io-block_size: ${IO_BLOCK_SIZE}"
+  echo "io-workers: ${IO_WORKERS}"
+  echo "io-write-bytes: ${IO_WRITE_BYTES}"
+} > "$SCENARIO_FILE_PATH"
+
+# Generate standalone config
+cat > $KRAKEN_FOLDER/config/baremetal-io-hog-config.yaml <<EOF
+kraken:
+    execution_mode: standalone
+    kubeconfig_path:
+    exit_on_failure: False
+    publish_kraken_status: False
+    signal_state: RUN
+    signal_address: 0.0.0.0
+    port: 8081
+    chaos_scenarios:
+        - $SCENARIO_TYPE:
+            - $SCENARIO_FILE
+
+tunings:
+    wait_duration: ${WAIT_DURATION:-10}
+    iterations: ${ITERATIONS:-1}
+    daemon_mode: False
+
+performance_monitoring:
+    prometheus_url:
+    prometheus_bearer_token:
+    uuid:
+    enable_alerts: False
+    enable_metrics: False
+    alert_profile:
+    metrics_profile:
+    check_critical_alerts: False
+
+cerberus:
+    cerberus_enabled: False
+    cerberus_url:
+
+elastic:
+    enable_elastic: False
+
+telemetry:
+    enabled: False
+
+resiliency:
+    resiliency_run_mode: disabled
+EOF
+
+if [[ $KRKN_DEBUG == "True" ]]; then
+  cat $SCENARIO_FILE_PATH
+  cat $KRAKEN_FOLDER/config/baremetal-io-hog-config.yaml
+fi
+
+# Run Kraken
+cd $KRAKEN_FOLDER
+extra_var=""
+if [[ $KRKN_DEBUG == "True" ]]; then
+  extra_var="--debug True"
+fi
+
+python3.11 run_kraken.py --config=config/baremetal-io-hog-config.yaml $extra_var

--- a/baremetal-memory-hog/Dockerfile.template
+++ b/baremetal-memory-hog/Dockerfile.template
@@ -1,0 +1,13 @@
+FROM quay.io/krkn-chaos/krkn:latest
+
+# Copy configurations
+COPY baremetal-memory-hog/env.sh /home/krkn/env.sh
+COPY env.sh /home/krkn/main_env.sh
+COPY baremetal-memory-hog/run.sh /home/krkn/run.sh
+
+LABEL krknctl.title="Baremetal Memory Hog"
+LABEL krknctl.description="Memory stress test on baremetal/standalone hosts via SSH using stress-ng. Targets hosts directly without requiring Kubernetes."
+
+LABEL krknctl.input_fields='$KRKNCTL_INPUT'
+
+ENTRYPOINT /home/krkn/run.sh

--- a/baremetal-memory-hog/env.sh
+++ b/baremetal-memory-hog/env.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Vars and respective defaults
+export TARGETS=${TARGETS:=""}
+export SSH_USER=${SSH_USER:="root"}
+export SSH_PRIVATE_KEY=${SSH_PRIVATE_KEY:="/home/krkn/.ssh/id_rsa"}
+export SSH_PORT=${SSH_PORT:="22"}
+export NUMBER_OF_WORKERS=${NUMBER_OF_WORKERS:="1"}
+export MEMORY_VM_BYTES=${MEMORY_VM_BYTES:="256M"}
+export TOTAL_CHAOS_DURATION=${TOTAL_CHAOS_DURATION:="60"}
+
+export SCENARIO_TYPE=${SCENARIO_TYPE:=hog_scenarios}
+export SCENARIO_FILE=${SCENARIO_FILE:=scenarios/standalone/baremetal-memory-hog.yml}

--- a/baremetal-memory-hog/krknctl-input.json
+++ b/baremetal-memory-hog/krknctl-input.json
@@ -1,0 +1,62 @@
+[
+    {
+        "name": "targets",
+        "short_description": "Target Hosts",
+        "description": "Comma-separated list of target host IPs or hostnames to stress (e.g., 192.168.1.100,192.168.1.101)",
+        "variable": "TARGETS",
+        "type": "string",
+        "required": "true"
+    },
+    {
+        "name": "ssh-user",
+        "short_description": "SSH User",
+        "description": "SSH username for connecting to target hosts",
+        "variable": "SSH_USER",
+        "type": "string",
+        "default": "root",
+        "required": "false"
+    },
+    {
+        "name": "ssh-private-key",
+        "short_description": "SSH Private Key Path",
+        "description": "Path to SSH private key file inside the container",
+        "variable": "SSH_PRIVATE_KEY",
+        "type": "string",
+        "default": "/home/krkn/.ssh/id_rsa",
+        "required": "false"
+    },
+    {
+        "name": "ssh-port",
+        "short_description": "SSH Port",
+        "description": "SSH port for connecting to target hosts",
+        "variable": "SSH_PORT",
+        "type": "number",
+        "default": "22",
+        "required": "false"
+    },
+    {
+        "name": "memory-workers",
+        "short_description": "Memory Workers",
+        "description": "Number of stress-ng memory worker threads",
+        "variable": "NUMBER_OF_WORKERS",
+        "type": "number",
+        "default": "1",
+        "required": "false"
+    },
+    {
+        "name": "memory-vm-bytes",
+        "short_description": "Memory VM Bytes",
+        "description": "Amount of memory to consume per worker (e.g., 256M, 1G, 512K)",
+        "variable": "MEMORY_VM_BYTES",
+        "type": "string",
+        "default": "256M"
+    },
+    {
+        "name": "chaos-duration",
+        "short_description": "Chaos Duration",
+        "description": "Duration of memory stress in seconds",
+        "variable": "TOTAL_CHAOS_DURATION",
+        "type": "number",
+        "default": "60"
+    }
+]

--- a/baremetal-memory-hog/run.sh
+++ b/baremetal-memory-hog/run.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+ROOT_FOLDER="/home/krkn"
+KRAKEN_FOLDER="$ROOT_FOLDER/kraken"
+SCENARIO_FOLDER="$KRAKEN_FOLDER/scenarios/standalone"
+
+# Source env.sh to read all the vars
+source $ROOT_FOLDER/main_env.sh
+source $ROOT_FOLDER/env.sh
+
+if [[ $KRKN_DEBUG == "True" ]]; then
+  set -ex
+fi
+
+mkdir -p $SCENARIO_FOLDER
+
+# Validate inputs to prevent injection
+validate_input() {
+  local name="$1" value="$2" pattern="$3"
+  if [[ ! "$value" =~ $pattern ]]; then
+    echo "ERROR: Invalid $name: $value" >&2
+    exit 1
+  fi
+}
+
+validate_input "SSH_USER" "$SSH_USER" '^[a-zA-Z0-9_.-]+$'
+
+# Generate scenario YAML
+SCENARIO_FILE_PATH="$KRAKEN_FOLDER/$SCENARIO_FILE"
+{
+  echo "hog-type: memory"
+  echo "targets:"
+  IFS=',' read -ra TARGET_ARRAY <<< "$TARGETS"
+  for target in "${TARGET_ARRAY[@]}"; do
+    target=$(echo "$target" | xargs)
+    if [[ -n "$target" ]]; then
+      validate_input "TARGET" "$target" '^[a-zA-Z0-9._:-]+$'
+      echo "  - ${target}"
+    fi
+  done
+  echo "ssh_user: ${SSH_USER}"
+  echo "ssh_private_key: ${SSH_PRIVATE_KEY}"
+  echo "ssh_port: ${SSH_PORT:-22}"
+  echo "node-selector: \"\""
+  echo "duration: ${TOTAL_CHAOS_DURATION}"
+  echo "workers: ${NUMBER_OF_WORKERS}"
+  echo "memory-vm-bytes: ${MEMORY_VM_BYTES}"
+} > "$SCENARIO_FILE_PATH"
+
+# Generate standalone config
+cat > $KRAKEN_FOLDER/config/baremetal-memory-hog-config.yaml <<EOF
+kraken:
+    execution_mode: standalone
+    kubeconfig_path:
+    exit_on_failure: False
+    publish_kraken_status: False
+    signal_state: RUN
+    signal_address: 0.0.0.0
+    port: 8081
+    chaos_scenarios:
+        - $SCENARIO_TYPE:
+            - $SCENARIO_FILE
+
+tunings:
+    wait_duration: ${WAIT_DURATION:-10}
+    iterations: ${ITERATIONS:-1}
+    daemon_mode: False
+
+performance_monitoring:
+    prometheus_url:
+    prometheus_bearer_token:
+    uuid:
+    enable_alerts: False
+    enable_metrics: False
+    alert_profile:
+    metrics_profile:
+    check_critical_alerts: False
+
+cerberus:
+    cerberus_enabled: False
+    cerberus_url:
+
+elastic:
+    enable_elastic: False
+
+telemetry:
+    enabled: False
+
+resiliency:
+    resiliency_run_mode: disabled
+EOF
+
+if [[ $KRKN_DEBUG == "True" ]]; then
+  cat $SCENARIO_FILE_PATH
+  cat $KRAKEN_FOLDER/config/baremetal-memory-hog-config.yaml
+fi
+
+# Run Kraken
+cd $KRAKEN_FOLDER
+extra_var=""
+if [[ $KRKN_DEBUG == "True" ]]; then
+  extra_var="--debug True"
+fi
+
+python3.11 run_kraken.py --config=config/baremetal-memory-hog-config.yaml $extra_var

--- a/baremetal-network-chaos/Dockerfile.template
+++ b/baremetal-network-chaos/Dockerfile.template
@@ -1,0 +1,13 @@
+FROM quay.io/krkn-chaos/krkn:latest
+
+# Copy configurations
+COPY baremetal-network-chaos/env.sh /home/krkn/env.sh
+COPY env.sh /home/krkn/main_env.sh
+COPY baremetal-network-chaos/run.sh /home/krkn/run.sh
+
+LABEL krknctl.title="Baremetal Network Chaos"
+LABEL krknctl.description="Network chaos (latency, packet loss, bandwidth restriction) on baremetal/standalone hosts via SSH using tc. Targets hosts directly without requiring Kubernetes."
+
+LABEL krknctl.input_fields='$KRKNCTL_INPUT'
+
+ENTRYPOINT /home/krkn/run.sh

--- a/baremetal-network-chaos/env.sh
+++ b/baremetal-network-chaos/env.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Vars and respective defaults
+export TARGETS=${TARGETS:=""}
+export SSH_USER=${SSH_USER:="root"}
+export SSH_PRIVATE_KEY=${SSH_PRIVATE_KEY:="/home/krkn/.ssh/id_rsa"}
+export SSH_PORT=${SSH_PORT:="22"}
+export DURATION=${DURATION:="300"}
+export INTERFACES=${INTERFACES:="[]"}
+export EXECUTION=${EXECUTION:="serial"}
+export LATENCY=${LATENCY:=""}
+export LOSS=${LOSS:=""}
+export BANDWIDTH=${BANDWIDTH:=""}
+
+export SCENARIO_TYPE=${SCENARIO_TYPE:=network_chaos_scenarios}
+export SCENARIO_FILE=${SCENARIO_FILE:=scenarios/standalone/baremetal-network-chaos.yml}

--- a/baremetal-network-chaos/krknctl-input.json
+++ b/baremetal-network-chaos/krknctl-input.json
@@ -1,0 +1,91 @@
+[
+    {
+        "name": "targets",
+        "short_description": "Target Hosts",
+        "description": "Comma-separated list of target host IPs or hostnames (e.g., 192.168.1.100,192.168.1.101)",
+        "variable": "TARGETS",
+        "type": "string",
+        "required": "true"
+    },
+    {
+        "name": "ssh-user",
+        "short_description": "SSH User",
+        "description": "SSH username for connecting to target hosts",
+        "variable": "SSH_USER",
+        "type": "string",
+        "default": "root",
+        "required": "false"
+    },
+    {
+        "name": "ssh-private-key",
+        "short_description": "SSH Private Key Path",
+        "description": "Path to SSH private key file inside the container",
+        "variable": "SSH_PRIVATE_KEY",
+        "type": "string",
+        "default": "/home/krkn/.ssh/id_rsa",
+        "required": "false"
+    },
+    {
+        "name": "ssh-port",
+        "short_description": "SSH Port",
+        "description": "SSH port for connecting to target hosts",
+        "variable": "SSH_PORT",
+        "type": "number",
+        "default": "22",
+        "required": "false"
+    },
+    {
+        "name": "duration",
+        "short_description": "Duration",
+        "description": "Duration in seconds for network chaos to be applied",
+        "variable": "DURATION",
+        "type": "number",
+        "default": "300",
+        "required": "false"
+    },
+    {
+        "name": "interfaces",
+        "short_description": "Network Interfaces",
+        "description": "List of interfaces to apply chaos on (e.g., [eth0,eth1]). Empty list auto-detects.",
+        "variable": "INTERFACES",
+        "type": "string",
+        "default": "[]",
+        "required": "false"
+    },
+    {
+        "name": "execution",
+        "short_description": "Execution Mode",
+        "description": "Execute chaos parameters as a single scenario (parallel) or separate scenarios (serial)",
+        "variable": "EXECUTION",
+        "type": "enum",
+        "allowed_values": "parallel,serial",
+        "separator": ",",
+        "default": "serial",
+        "required": "false"
+    },
+    {
+        "name": "latency",
+        "short_description": "Network Latency",
+        "description": "Network latency to inject (e.g., 100ms, 500ms)",
+        "variable": "LATENCY",
+        "type": "string",
+        "default": "100ms",
+        "required": "false"
+    },
+    {
+        "name": "loss",
+        "short_description": "Packet Loss",
+        "description": "Packet loss percentage to inject (e.g., 0.02 for 2%)",
+        "variable": "LOSS",
+        "type": "string",
+        "required": "false"
+    },
+    {
+        "name": "bandwidth",
+        "short_description": "Bandwidth Limit",
+        "description": "Bandwidth restriction to apply (e.g., 100mbit)",
+        "variable": "BANDWIDTH",
+        "type": "string",
+        "required": "false"
+    }
+]

--- a/baremetal-network-chaos/run.sh
+++ b/baremetal-network-chaos/run.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+ROOT_FOLDER="/home/krkn"
+KRAKEN_FOLDER="$ROOT_FOLDER/kraken"
+SCENARIO_FOLDER="$KRAKEN_FOLDER/scenarios/standalone"
+
+# Source env.sh to read all the vars
+source $ROOT_FOLDER/main_env.sh
+source $ROOT_FOLDER/env.sh
+
+if [[ $KRKN_DEBUG == "True" ]]; then
+  set -ex
+fi
+
+mkdir -p $SCENARIO_FOLDER
+
+# Validate inputs to prevent injection
+validate_input() {
+  local name="$1" value="$2" pattern="$3"
+  if [[ ! "$value" =~ $pattern ]]; then
+    echo "ERROR: Invalid $name: $value" >&2
+    exit 1
+  fi
+}
+
+validate_input "SSH_USER" "$SSH_USER" '^[a-zA-Z0-9_.-]+$'
+validate_input "INTERFACES" "$INTERFACES" '^[a-zA-Z0-9_,. -]+$'
+validate_input "EXECUTION" "$EXECUTION" '^(serial|parallel)$'
+if [[ -n "$LATENCY" ]]; then
+  validate_input "LATENCY" "$LATENCY" '^[0-9]+[a-z]*$'
+fi
+if [[ -n "$LOSS" ]]; then
+  validate_input "LOSS" "$LOSS" '^[0-9]+(\.[0-9]+)?%?$'
+fi
+if [[ -n "$BANDWIDTH" ]]; then
+  validate_input "BANDWIDTH" "$BANDWIDTH" '^[0-9]+[a-z]*$'
+fi
+
+# Generate scenario YAML
+SCENARIO_FILE_PATH="$KRAKEN_FOLDER/$SCENARIO_FILE"
+{
+  echo "network_chaos:"
+  echo "  targets:"
+  IFS=',' read -ra TARGET_ARRAY <<< "$TARGETS"
+  for target in "${TARGET_ARRAY[@]}"; do
+    target=$(echo "$target" | xargs)
+    if [[ -n "$target" ]]; then
+      validate_input "TARGET" "$target" '^[a-zA-Z0-9._:-]+$'
+      echo "    - ${target}"
+    fi
+  done
+  echo "  ssh_user: ${SSH_USER}"
+  echo "  ssh_private_key: ${SSH_PRIVATE_KEY}"
+  echo "  ssh_port: ${SSH_PORT:-22}"
+  echo "  duration: ${DURATION}"
+  echo "  interfaces: ${INTERFACES}"
+  echo "  execution: ${EXECUTION}"
+  echo "  egress:"
+  if [[ -n "$LATENCY" ]]; then
+    echo "    latency: ${LATENCY}"
+  fi
+  if [[ -n "$LOSS" ]]; then
+    echo "    loss: ${LOSS}"
+  fi
+  if [[ -n "$BANDWIDTH" ]]; then
+    echo "    bandwidth: ${BANDWIDTH}"
+  fi
+  # Default to latency if nothing specified
+  if [[ -z "$LATENCY" && -z "$LOSS" && -z "$BANDWIDTH" ]]; then
+    echo "    latency: 100ms"
+  fi
+} > "$SCENARIO_FILE_PATH"
+
+# Generate standalone config
+cat > $KRAKEN_FOLDER/config/baremetal-network-chaos-config.yaml <<EOF
+kraken:
+    execution_mode: standalone
+    kubeconfig_path:
+    exit_on_failure: False
+    publish_kraken_status: False
+    signal_state: RUN
+    signal_address: 0.0.0.0
+    port: 8081
+    chaos_scenarios:
+        - $SCENARIO_TYPE:
+            - $SCENARIO_FILE
+
+tunings:
+    wait_duration: ${WAIT_DURATION:-10}
+    iterations: ${ITERATIONS:-1}
+    daemon_mode: False
+
+performance_monitoring:
+    prometheus_url:
+    prometheus_bearer_token:
+    uuid:
+    enable_alerts: False
+    enable_metrics: False
+    alert_profile:
+    metrics_profile:
+    check_critical_alerts: False
+
+cerberus:
+    cerberus_enabled: False
+    cerberus_url:
+
+elastic:
+    enable_elastic: False
+
+telemetry:
+    enabled: False
+
+resiliency:
+    resiliency_run_mode: disabled
+EOF
+
+if [[ $KRKN_DEBUG == "True" ]]; then
+  cat $SCENARIO_FILE_PATH
+  cat $KRAKEN_FOLDER/config/baremetal-network-chaos-config.yaml
+fi
+
+# Run Kraken
+cd $KRAKEN_FOLDER
+extra_var=""
+if [[ $KRKN_DEBUG == "True" ]]; then
+  extra_var="--debug True"
+fi
+
+python3.11 run_kraken.py --config=config/baremetal-network-chaos-config.yaml $extra_var

--- a/baremetal-node-ssh/Dockerfile.template
+++ b/baremetal-node-ssh/Dockerfile.template
@@ -1,0 +1,13 @@
+FROM quay.io/krkn-chaos/krkn:latest
+
+# Copy configurations
+COPY baremetal-node-ssh/env.sh /home/krkn/env.sh
+COPY env.sh /home/krkn/main_env.sh
+COPY baremetal-node-ssh/run.sh /home/krkn/run.sh
+
+LABEL krknctl.title="Baremetal Node SSH"
+LABEL krknctl.description="Node disruption (reboot, crash, shutdown) on baremetal/standalone hosts via SSH. Targets hosts directly without requiring Kubernetes or BMC/IPMI."
+
+LABEL krknctl.input_fields='$KRKNCTL_INPUT'
+
+ENTRYPOINT /home/krkn/run.sh

--- a/baremetal-node-ssh/env.sh
+++ b/baremetal-node-ssh/env.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Vars and respective defaults
+export TARGETS=${TARGETS:=""}
+export SSH_USER=${SSH_USER:="root"}
+export SSH_PRIVATE_KEY=${SSH_PRIVATE_KEY:="/home/krkn/.ssh/id_rsa"}
+export SSH_PORT=${SSH_PORT:="22"}
+export ACTION=${ACTION:="node_reboot_scenario"}
+export RUNS=${RUNS:="1"}
+export TIMEOUT=${TIMEOUT:="360"}
+export SOFT_REBOOT=${SOFT_REBOOT:="true"}
+
+export SCENARIO_TYPE=${SCENARIO_TYPE:=node_scenarios}
+export SCENARIO_FILE=${SCENARIO_FILE:=scenarios/standalone/baremetal-node-ssh.yml}

--- a/baremetal-node-ssh/krknctl-input.json
+++ b/baremetal-node-ssh/krknctl-input.json
@@ -1,0 +1,77 @@
+[
+    {
+        "name": "targets",
+        "short_description": "Target Hosts",
+        "description": "Comma-separated list of target host IPs or hostnames (e.g., 192.168.1.100,192.168.1.101)",
+        "variable": "TARGETS",
+        "type": "string",
+        "required": "true"
+    },
+    {
+        "name": "ssh-user",
+        "short_description": "SSH User",
+        "description": "SSH username for connecting to target hosts",
+        "variable": "SSH_USER",
+        "type": "string",
+        "default": "root",
+        "required": "false"
+    },
+    {
+        "name": "ssh-private-key",
+        "short_description": "SSH Private Key Path",
+        "description": "Path to SSH private key file inside the container",
+        "variable": "SSH_PRIVATE_KEY",
+        "type": "string",
+        "default": "/home/krkn/.ssh/id_rsa",
+        "required": "false"
+    },
+    {
+        "name": "ssh-port",
+        "short_description": "SSH Port",
+        "description": "SSH port for connecting to target hosts",
+        "variable": "SSH_PORT",
+        "type": "number",
+        "default": "22",
+        "required": "false"
+    },
+    {
+        "name": "action",
+        "short_description": "Action",
+        "description": "Node disruption action to perform: node_reboot_scenario, node_crash_scenario, or stop_start_helper_node_scenario",
+        "variable": "ACTION",
+        "type": "enum",
+        "allowed_values": "node_reboot_scenario,node_crash_scenario,stop_start_helper_node_scenario",
+        "separator": ",",
+        "default": "node_reboot_scenario",
+        "required": "false"
+    },
+    {
+        "name": "runs",
+        "short_description": "Runs",
+        "description": "Number of times to execute the action",
+        "variable": "RUNS",
+        "type": "number",
+        "default": "1",
+        "required": "false"
+    },
+    {
+        "name": "timeout",
+        "short_description": "Timeout",
+        "description": "Timeout in seconds to wait for node to recover after disruption",
+        "variable": "TIMEOUT",
+        "type": "number",
+        "default": "360",
+        "required": "false"
+    },
+    {
+        "name": "soft-reboot",
+        "short_description": "Soft Reboot",
+        "description": "Use soft reboot (true) or hard reboot via sysrq (false)",
+        "variable": "SOFT_REBOOT",
+        "type": "enum",
+        "allowed_values": "true,false",
+        "separator": ",",
+        "default": "true",
+        "required": "false"
+    }
+]

--- a/baremetal-node-ssh/run.sh
+++ b/baremetal-node-ssh/run.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+ROOT_FOLDER="/home/krkn"
+KRAKEN_FOLDER="$ROOT_FOLDER/kraken"
+SCENARIO_FOLDER="$KRAKEN_FOLDER/scenarios/standalone"
+
+# Source env.sh to read all the vars
+source $ROOT_FOLDER/main_env.sh
+source $ROOT_FOLDER/env.sh
+
+if [[ $KRKN_DEBUG == "True" ]]; then
+  set -ex
+fi
+
+mkdir -p $SCENARIO_FOLDER
+
+# Validate inputs to prevent injection
+validate_input() {
+  local name="$1" value="$2" pattern="$3"
+  if [[ ! "$value" =~ $pattern ]]; then
+    echo "ERROR: Invalid $name: $value" >&2
+    exit 1
+  fi
+}
+
+validate_input "ACTION" "$ACTION" '^[a-z_]+$'
+validate_input "SSH_USER" "$SSH_USER" '^[a-zA-Z0-9_.-]+$'
+validate_input "SSH_PORT" "$SSH_PORT" '^[0-9]+$'
+
+# Convert comma-separated TARGETS to YAML list
+# Write targets via printf to avoid shell expansion
+SCENARIO_FILE_PATH="$KRAKEN_FOLDER/$SCENARIO_FILE"
+{
+  echo "node_scenarios:"
+  echo "  - actions:"
+  echo "      - ${ACTION}"
+  echo "    cloud_type: ssh"
+  echo "    targets:"
+  IFS=',' read -ra TARGET_ARRAY <<< "$TARGETS"
+  for target in "${TARGET_ARRAY[@]}"; do
+    target=$(echo "$target" | xargs)
+    if [[ -n "$target" ]]; then
+      validate_input "TARGET" "$target" '^[a-zA-Z0-9._:-]+$'
+      echo "      - ${target}"
+    fi
+  done
+  echo "    ssh_user: ${SSH_USER}"
+  echo "    ssh_private_key: ${SSH_PRIVATE_KEY}"
+  echo "    ssh_port: ${SSH_PORT}"
+  echo "    runs: ${RUNS}"
+  echo "    timeout: ${TIMEOUT}"
+  echo "    kube_check: false"
+  echo "    soft_reboot: ${SOFT_REBOOT}"
+} > "$SCENARIO_FILE_PATH"
+
+# Generate standalone config
+cat > $KRAKEN_FOLDER/config/baremetal-node-ssh-config.yaml <<EOF
+kraken:
+    execution_mode: standalone
+    kubeconfig_path:
+    exit_on_failure: False
+    publish_kraken_status: False
+    signal_state: RUN
+    signal_address: 0.0.0.0
+    port: 8081
+    chaos_scenarios:
+        - $SCENARIO_TYPE:
+            - $SCENARIO_FILE
+
+tunings:
+    wait_duration: ${WAIT_DURATION:-10}
+    iterations: ${ITERATIONS:-1}
+    daemon_mode: False
+
+performance_monitoring:
+    prometheus_url:
+    prometheus_bearer_token:
+    uuid:
+    enable_alerts: False
+    enable_metrics: False
+    alert_profile:
+    metrics_profile:
+    check_critical_alerts: False
+
+cerberus:
+    cerberus_enabled: False
+    cerberus_url:
+
+elastic:
+    enable_elastic: False
+
+telemetry:
+    enabled: False
+
+resiliency:
+    resiliency_run_mode: disabled
+EOF
+
+if [[ $KRKN_DEBUG == "True" ]]; then
+  cat $SCENARIO_FILE_PATH
+  cat $KRAKEN_FOLDER/config/baremetal-node-ssh-config.yaml
+fi
+
+# Run Kraken
+cd $KRAKEN_FOLDER
+extra_var=""
+if [[ $KRKN_DEBUG == "True" ]]; then
+  extra_var="--debug True"
+fi
+
+python3.11 run_kraken.py --config=config/baremetal-node-ssh-config.yaml $extra_var

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,8 @@
 SCENARIOS=( application-outages container-scenarios network-chaos node-cpu-hog node-io-hog \
 node-memory-hog node-scenarios node-scenarios-bm pod-network-chaos pod-scenarios power-outages pvc-scenario \
 service-disruption-scenarios service-hijacking syn-flood time-scenarios zone-outages node-network-filter pod-network-filter kubevirt-outage node-interface-down http-load rollback vmi-network-filter vmi-network \
-dummy-scenario storage-throttle)
+dummy-scenario storage-throttle \
+baremetal-cpu-hog baremetal-memory-hog baremetal-io-hog baremetal-network-chaos baremetal-node-ssh)
 for i in "${SCENARIOS[@]}"; do
     export KRKNCTL_INPUT=$(cat $i/krknctl-input.json|tr -d "\n")
     envsubst < $i/Dockerfile.template > $i/Dockerfile


### PR DESCRIPTION
# Description

Add 5 container images for standalone chaos via SSH (no Kubernetes required):
- **baremetal-cpu-hog**: CPU stress via stress-ng
- **baremetal-memory-hog**: memory stress via stress-ng
- **baremetal-io-hog**: IO stress via stress-ng
- **baremetal-network-chaos**: latency/loss/bandwidth via tc netem
- **baremetal-node-ssh**: node reboot/crash/shutdown via SSH

All containers use `execution_mode: standalone`, generate scenario YAMLs from environment variables, and include `validate_input()` regex checks to prevent shell injection.

## Related PRs
- krkn-chaos/krkn#1458: standalone execution mode

## Test plan
- [x] All 5 run.sh/env.sh shell syntax valid
- [x] All 5 krknctl-input.json valid JSON
- [x] Input validation present in all scripts
- [x] Zero unsafe echo -e patterns