### PR TITLE
feat: add node-network-chaos krknctl scenario image

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 SCENARIOS=( application-outages container-scenarios network-chaos node-cpu-hog node-io-hog \
 node-memory-hog node-scenarios node-scenarios-bm pod-network-chaos pod-scenarios power-outages pvc-scenario \
 service-disruption-scenarios service-hijacking syn-flood time-scenarios zone-outages node-network-filter pod-network-filter kubevirt-outage node-interface-down http-load rollback vmi-network-filter vmi-network \
-dummy-scenario storage-throttle)
+dummy-scenario storage-throttle node-network-chaos)
 for i in "${SCENARIOS[@]}"; do
     export KRKNCTL_INPUT=$(cat $i/krknctl-input.json|tr -d "\n")
     envsubst < $i/Dockerfile.template > $i/Dockerfile

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -152,5 +152,5 @@ services:
     node-network-chaos:
       build:
         context: ./
-        dockerfile: ./node-network-chaos/Dockerfile.template
+        dockerfile: ./node-network-chaos/Dockerfile
       image: quay.io/krkn-chaos/krkn-hub:node-network-chaos

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -149,3 +149,8 @@ services:
         context: ./
         dockerfile: ./dummy-scenario/Dockerfile
       image: quay.io/krkn-chaos/krkn-hub:dummy-scenario
+    node-network-chaos:
+      build:
+        context: ./
+        dockerfile: ./node-network-chaos/Dockerfile.template
+      image: quay.io/krkn-chaos/krkn-hub:node-network-chaos

--- a/node-network-chaos/Dockerfile.template
+++ b/node-network-chaos/Dockerfile.template
@@ -1,35 +1,16 @@
-# Dockerfile.template — node-network-chaos krknctl scenario image.
-#
-# Build hierarchy:
-#   quay.io/krkn-chaos/krkn:latest   (base: Python runtime + krkn source)
-#       └── quay.io/krkn-chaos/krkn-hub:node-network-chaos  (this image)
-#
-# At build time krkn-hub's build.sh runs compile_dockerfile.sh which substitutes
-# $KRKNCTL_INPUT with the minified JSON from node-network-chaos/krknctl-input.json.
-#
-# The image is published to: quay.io/krkn-chaos/krkn-hub:node-network-chaos
-
 FROM quay.io/krkn-chaos/krkn:latest
 
 ENV KUBECONFIG /home/krkn/.kube/config
 
-# ── Shared krkn-hub templates ─────────────────────────────────────────────────
-# These two templates are shared by every scenario image.
 COPY metrics_config.yaml.template /home/krkn/kraken/config/kube_burner.yaml.template
 COPY config.yaml.template         /home/krkn/kraken/config/config.yaml.template
 
-# ── Scenario-specific files ───────────────────────────────────────────────────
-# env.sh       — default environment variable values for this scenario
-# run.sh       — entrypoint: populates YAML, generates config, runs krkn
-# common_run.sh — shared helpers (checks, logging) from krkn-hub root
-# node-network-chaos.yml — seed scenario YAML mutated at runtime by run.sh
 COPY node-network-chaos/env.sh                 /home/krkn/env.sh
 COPY env.sh                                    /home/krkn/main_env.sh
 COPY node-network-chaos/run.sh                 /home/krkn/run.sh
 COPY common_run.sh                             /home/krkn/common_run.sh
 COPY node-network-chaos/node-network-chaos.yml /home/krkn/kraken/scenarios/kube/node-network-chaos.yml
 
-# ── krknctl metadata labels ───────────────────────────────────────────────────
 # krknctl reads these labels to populate `krknctl list` and `krknctl run --help`.
 # $KRKNCTL_INPUT is substituted at build time with the minified JSON from
 # node-network-chaos/krknctl-input.json (see krkn-hub build.sh / compile_dockerfile.sh).

--- a/node-network-chaos/Dockerfile.template
+++ b/node-network-chaos/Dockerfile.template
@@ -1,0 +1,43 @@
+# Dockerfile.template — node-network-chaos krknctl scenario image.
+#
+# Build hierarchy:
+#   quay.io/krkn-chaos/krkn:latest   (base: Python runtime + krkn source)
+#       └── quay.io/krkn-chaos/krkn-hub:node-network-chaos  (this image)
+#
+# At build time krkn-hub's build.sh runs compile_dockerfile.sh which substitutes
+# $KRKNCTL_INPUT with the minified JSON from node-network-chaos/krknctl-input.json.
+#
+# The image is published to: quay.io/krkn-chaos/krkn-hub:node-network-chaos
+
+FROM quay.io/krkn-chaos/krkn:latest
+
+ENV KUBECONFIG /home/krkn/.kube/config
+
+# ── Shared krkn-hub templates ─────────────────────────────────────────────────
+# These two templates are shared by every scenario image.
+COPY metrics_config.yaml.template /home/krkn/kraken/config/kube_burner.yaml.template
+COPY config.yaml.template         /home/krkn/kraken/config/config.yaml.template
+
+# ── Scenario-specific files ───────────────────────────────────────────────────
+# env.sh       — default environment variable values for this scenario
+# run.sh       — entrypoint: populates YAML, generates config, runs krkn
+# common_run.sh — shared helpers (checks, logging) from krkn-hub root
+# node-network-chaos.yml — seed scenario YAML mutated at runtime by run.sh
+COPY node-network-chaos/env.sh                 /home/krkn/env.sh
+COPY env.sh                                    /home/krkn/main_env.sh
+COPY node-network-chaos/run.sh                 /home/krkn/run.sh
+COPY common_run.sh                             /home/krkn/common_run.sh
+COPY node-network-chaos/node-network-chaos.yml /home/krkn/kraken/scenarios/kube/node-network-chaos.yml
+
+# ── krknctl metadata labels ───────────────────────────────────────────────────
+# krknctl reads these labels to populate `krknctl list` and `krknctl run --help`.
+# $KRKNCTL_INPUT is substituted at build time with the minified JSON from
+# node-network-chaos/krknctl-input.json (see krkn-hub build.sh / compile_dockerfile.sh).
+LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.has_rollback="false"
+LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
+LABEL krknctl.title="Node Network Chaos"
+LABEL krknctl.description="Applies node-level tc (traffic control) network shaping — latency, packet loss, and bandwidth restriction — using the NG network_chaos plugin. Implements an HTB+netem qdisc tree for accurate bandwidth control, real-time error feedback via kubectl exec, input validation before injection, and reliable cleanup through Python finally blocks. No hardcoded pre/post sleep delays."
+LABEL krknctl.input_fields='$KRKNCTL_INPUT'
+
+ENTRYPOINT ["/bin/bash", "/home/krkn/run.sh"]

--- a/node-network-chaos/env.sh
+++ b/node-network-chaos/env.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# env.sh — default environment variables for the node-network-chaos scenario.
+#
+# These variables are read by run.sh, which uses them to populate the scenario
+# YAML before krkn executes. Every variable here corresponds to a field in
+# NetworkChaosConfig (krkn/scenario_plugins/network_chaos_ng/models.py).
+#
+# The := syntax means: use the caller-supplied value if set; fall back to the
+# literal default on the right-hand side.
+
+# ── Targeting ────────────────────────────────────────────────────────────────
+# Which node(s) to target. Provide either a label selector OR a node name.
+export LABEL_SELECTOR=${LABEL_SELECTOR:=""}   # e.g. "node-role.kubernetes.io/worker"
+export NODE_NAME=${NODE_NAME:=""}             # e.g. "worker-0.example.com"
+
+# ── Scheduling ───────────────────────────────────────────────────────────────
+# How many nodes to target and how to run them.
+export INSTANCE_COUNT=${INSTANCE_COUNT:="1"}          # number of nodes
+export EXECUTION=${EXECUTION:="parallel"}             # parallel | serial
+
+# ── Kubernetes context ────────────────────────────────────────────────────────
+export NAMESPACE=${NAMESPACE:="default"}              # namespace for the helper pod
+export SERVICE_ACCOUNT=${SERVICE_ACCOUNT:=""}         # optional service account
+export IMAGE=${IMAGE:="quay.io/krkn-chaos/krkn:tools"} # helper pod image
+export TAINTS=${TAINTS:="[]"}                         # node taints (YAML array string)
+
+# ── Network interfaces ────────────────────────────────────────────────────────
+# Which interfaces to apply tc rules on. Empty = all interfaces.
+export INTERFACES=${INTERFACES:="[]"}                 # e.g. "[br-ex]" or "[eth0,eth1]"
+
+# ── Traffic direction ─────────────────────────────────────────────────────────
+# JSON/YAML-style list. Supported values: egress, ingress, or both.
+export TRAFFIC_TYPE=${TRAFFIC_TYPE:="[egress]"}       # e.g. "[egress]" or "[ingress,egress]"
+
+# ── tc netem shaping parameters ───────────────────────────────────────────────
+# At least one of latency, loss, or bandwidth must be provided.
+export LATENCY=${LATENCY:=""}                         # e.g. "200ms"  (units: us, ms, s)
+export LOSS=${LOSS:=""}                               # e.g. "10"     (%, digits only)
+export BANDWIDTH=${BANDWIDTH:=""}                     # e.g. "100mbit" (units: bit..tbit)
+
+# ── Timing ────────────────────────────────────────────────────────────────────
+export TEST_DURATION=${TEST_DURATION:="120"}          # seconds to hold chaos
+export WAIT_DURATION=${WAIT_DURATION:="0"}            # post-chaos wait (seconds)
+
+# ── Safety ────────────────────────────────────────────────────────────────────
+# force=true removes any pre-existing tc qdiscs before applying new ones.
+export FORCE=${FORCE:="false"}                        # true | false

--- a/node-network-chaos/env.sh
+++ b/node-network-chaos/env.sh
@@ -21,7 +21,7 @@ export EXECUTION=${EXECUTION:="parallel"}             # parallel | serial
 # ── Kubernetes context ────────────────────────────────────────────────────────
 export NAMESPACE=${NAMESPACE:="default"}              # namespace for the helper pod
 export SERVICE_ACCOUNT=${SERVICE_ACCOUNT:=""}         # optional service account
-export IMAGE=${IMAGE:="quay.io/krkn-chaos/krkn:tools"} # helper pod image
+export IMAGE=${IMAGE:="quay.io/krkn-chaos/krkn-network-chaos:latest"} # helper pod image
 export TAINTS=${TAINTS:="[]"}                         # node taints (YAML array string)
 
 # ── Network interfaces ────────────────────────────────────────────────────────

--- a/node-network-chaos/krknctl-input.json
+++ b/node-network-chaos/krknctl-input.json
@@ -117,7 +117,7 @@
     "description": "Container image used for the chaos helper pod that applies tc rules on the node.",
     "variable": "IMAGE",
     "type": "string",
-    "default": "quay.io/krkn-chaos/krkn:tools",
+    "default": "quay.io/krkn-chaos/krkn-network-chaos:latest",
     "required": "false"
   },
   {

--- a/node-network-chaos/krknctl-input.json
+++ b/node-network-chaos/krknctl-input.json
@@ -1,0 +1,141 @@
+[
+  {
+    "name": "label-selector",
+    "short_description": "Node label selector",
+    "description": "Label selector to target one or more nodes (e.g. node-role.kubernetes.io/worker). If omitted, NODE_NAME is used instead.",
+    "variable": "LABEL_SELECTOR",
+    "type": "string",
+    "default": "",
+    "required": "false"
+  },
+  {
+    "name": "node-name",
+    "short_description": "Target node name",
+    "description": "Exact node name to target when label-selector is not specified.",
+    "variable": "NODE_NAME",
+    "type": "string",
+    "default": "",
+    "required": "false"
+  },
+  {
+    "name": "instance-count",
+    "short_description": "Number of nodes to target",
+    "description": "How many nodes matching the selector to apply chaos on simultaneously.",
+    "variable": "INSTANCE_COUNT",
+    "type": "number",
+    "default": "1",
+    "required": "false"
+  },
+  {
+    "name": "interfaces",
+    "short_description": "Network interfaces",
+    "description": "YAML-style list of interface names to shape (e.g. [br-ex] or [eth0,eth1]). Leave empty to target all interfaces.",
+    "variable": "INTERFACES",
+    "type": "string",
+    "default": "[]",
+    "required": "false"
+  },
+  {
+    "name": "traffic-type",
+    "short_description": "Traffic direction(s)",
+    "description": "Direction of traffic to shape. Accepted values: [egress], [ingress], or [egress,ingress].",
+    "variable": "TRAFFIC_TYPE",
+    "type": "string",
+    "default": "[egress]",
+    "required": "false"
+  },
+  {
+    "name": "latency",
+    "short_description": "Network latency to inject",
+    "description": "Artificial delay to add to matching packets. Format: <number><unit> where unit is us, ms, or s (e.g. 200ms).",
+    "variable": "LATENCY",
+    "type": "string",
+    "default": "",
+    "required": "false"
+  },
+  {
+    "name": "loss",
+    "short_description": "Packet loss percentage",
+    "description": "Percentage of packets to drop. Digits only, no % symbol (e.g. 10 means 10%).",
+    "variable": "LOSS",
+    "type": "string",
+    "default": "",
+    "required": "false"
+  },
+  {
+    "name": "bandwidth",
+    "short_description": "Bandwidth limit",
+    "description": "Maximum throughput for matching traffic. Format: <number><unit> where unit is bit, kbit, mbit, gbit, or tbit (e.g. 100mbit).",
+    "variable": "BANDWIDTH",
+    "type": "string",
+    "default": "",
+    "required": "false"
+  },
+  {
+    "name": "test-duration",
+    "short_description": "Chaos duration (seconds)",
+    "description": "How long (in seconds) to hold the tc rules before cleanup.",
+    "variable": "TEST_DURATION",
+    "type": "number",
+    "default": "120",
+    "required": "false"
+  },
+  {
+    "name": "execution",
+    "short_description": "Execution mode",
+    "description": "Whether to apply chaos to all target nodes in parallel or one at a time.",
+    "variable": "EXECUTION",
+    "type": "enum",
+    "allowed_values": "parallel,serial",
+    "separator": ",",
+    "default": "parallel",
+    "required": "false"
+  },
+  {
+    "name": "force",
+    "short_description": "Force qdisc replacement",
+    "description": "When true, removes any pre-existing tc qdiscs on the interface before applying new rules.",
+    "variable": "FORCE",
+    "type": "enum",
+    "allowed_values": "true,false",
+    "separator": ",",
+    "default": "false",
+    "required": "false"
+  },
+  {
+    "name": "namespace",
+    "short_description": "Deployment namespace",
+    "description": "Kubernetes namespace where the scenario helper pod will be scheduled.",
+    "variable": "NAMESPACE",
+    "type": "string",
+    "default": "default",
+    "required": "false"
+  },
+  {
+    "name": "image",
+    "short_description": "Helper pod image",
+    "description": "Container image used for the chaos helper pod that applies tc rules on the node.",
+    "variable": "IMAGE",
+    "type": "string",
+    "default": "quay.io/krkn-chaos/krkn:tools",
+    "required": "false"
+  },
+  {
+    "name": "service-account",
+    "short_description": "Service account name",
+    "description": "Kubernetes service account to assign to the helper pod (leave empty to use the namespace default).",
+    "variable": "SERVICE_ACCOUNT",
+    "type": "string",
+    "default": "",
+    "required": "false"
+  },
+  {
+    "name": "taints",
+    "short_description": "Node taints to tolerate",
+    "description": "YAML-style list of node taints the helper pod should tolerate (e.g. [NoSchedule]).",
+    "variable": "TAINTS",
+    "type": "string",
+    "default": "[]",
+    "required": "false"
+  }
+]

--- a/node-network-chaos/node-network-chaos.yml
+++ b/node-network-chaos/node-network-chaos.yml
@@ -7,7 +7,7 @@
 # id: node_network_chaos  ← registered in network_chaos_factory.py
 # plugin type: network_chaos_ng_scenarios  ← set in krkn config.yaml
 - id: node_network_chaos
-  image: "quay.io/krkn-chaos/krkn:tools"
+  image: "quay.io/krkn-chaos/krkn-network-chaos:latest"
   wait_duration: 0
   test_duration: 120
   label_selector: ""

--- a/node-network-chaos/node-network-chaos.yml
+++ b/node-network-chaos/node-network-chaos.yml
@@ -1,0 +1,26 @@
+# node-network-chaos.yml — seed scenario YAML for the node-network-chaos krknctl image.
+#
+# This file is the starting state. run.sh will mutate every field using `yq`
+# before krkn reads it. Key names MUST match the fields in NetworkChaosConfig
+# (krkn/scenario_plugins/network_chaos_ng/models.py).
+#
+# id: node_network_chaos  ← registered in network_chaos_factory.py
+# plugin type: network_chaos_ng_scenarios  ← set in krkn config.yaml
+- id: node_network_chaos
+  image: "quay.io/krkn-chaos/krkn:tools"
+  wait_duration: 0
+  test_duration: 120
+  label_selector: ""
+  service_account: ""
+  taints: []
+  namespace: "default"
+  instance_count: 1
+  target: ""
+  execution: parallel
+  interfaces: []
+  ingress: false
+  egress: true
+  latency: ""
+  loss: ""
+  bandwidth: ""
+  force: false

--- a/node-network-chaos/run.sh
+++ b/node-network-chaos/run.sh
@@ -20,8 +20,8 @@ CONFIG_TEMPLATE="$KRAKEN_FOLDER/config/config.yaml.template"
 CONFIG_OUT="$KRAKEN_FOLDER/config/node-network-chaos-config.yaml"
 
 # ── 1. Source environment ─────────────────────────────────────────────────────
+source "$ROOT_FOLDER/env.sh"        # scenario-specific defaults FIRST
 source "$ROOT_FOLDER/main_env.sh"   # global krkn-hub defaults (kubeconfig, cerberus, etc.)
-source "$ROOT_FOLDER/env.sh"        # scenario-specific defaults (this image's env.sh)
 source "$ROOT_FOLDER/common_run.sh" # defines the checks() helper function
 
 if [[ "$KRKN_DEBUG" == "True" ]]; then

--- a/node-network-chaos/run.sh
+++ b/node-network-chaos/run.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# run.sh — entrypoint for the node-network-chaos krknctl scenario image.
+#
+# Execution order:
+#   1. Source env files (globals → scenario-specific defaults)
+#   2. Mutate the seed YAML with runtime values using yq
+#   3. Derive ingress/egress booleans from the TRAFFIC_TYPE list variable
+#   4. Set the list-type fields (interfaces, taints) from their env vars
+#   5. Generate krkn config.yaml via envsubst
+#   6. Run pre-flight checks (kubectl/oc present, kubeconfig readable)
+#   7. Execute krkn
+
+set -eo pipefail
+
+ROOT_FOLDER="/home/krkn"
+KRAKEN_FOLDER="$ROOT_FOLDER/kraken"
+SCENARIO_FOLDER="$KRAKEN_FOLDER/scenarios/kube"
+SCENARIO_FILE="$SCENARIO_FOLDER/node-network-chaos.yml"
+CONFIG_TEMPLATE="$KRAKEN_FOLDER/config/config.yaml.template"
+CONFIG_OUT="$KRAKEN_FOLDER/config/node-network-chaos-config.yaml"
+
+# ── 1. Source environment ─────────────────────────────────────────────────────
+source "$ROOT_FOLDER/main_env.sh"   # global krkn-hub defaults (kubeconfig, cerberus, etc.)
+source "$ROOT_FOLDER/env.sh"        # scenario-specific defaults (this image's env.sh)
+source "$ROOT_FOLDER/common_run.sh" # defines the checks() helper function
+
+if [[ "$KRKN_DEBUG" == "True" ]]; then
+    set -x
+fi
+
+# ── 2. Scalar field mutations ─────────────────────────────────────────────────
+# Each yq command updates one field in the YAML list-item at index 0.
+# Integers: no quotes.  Strings: always double-quoted to survive special chars.
+yq -i ".[0].image=\"$IMAGE\""                 "$SCENARIO_FILE"
+yq -i ".[0].wait_duration=$WAIT_DURATION"     "$SCENARIO_FILE"
+yq -i ".[0].test_duration=$TEST_DURATION"     "$SCENARIO_FILE"
+yq -i ".[0].label_selector=\"$LABEL_SELECTOR\"" "$SCENARIO_FILE"
+yq -i ".[0].service_account=\"$SERVICE_ACCOUNT\"" "$SCENARIO_FILE"
+yq -i ".[0].namespace=\"$NAMESPACE\""         "$SCENARIO_FILE"
+yq -i ".[0].instance_count=$INSTANCE_COUNT"   "$SCENARIO_FILE"
+yq -i ".[0].execution=\"$EXECUTION\""         "$SCENARIO_FILE"
+yq -i ".[0].target=\"$NODE_NAME\""            "$SCENARIO_FILE"
+yq -i ".[0].force=$FORCE"                     "$SCENARIO_FILE"
+
+# ── 3. Optional tc netem parameters ──────────────────────────────────────────
+# Only write these if the caller supplied a value — an empty string is a valid
+# sentinel meaning "do not apply this shaping parameter".
+if [[ -n "$LATENCY" ]]; then
+    yq -i ".[0].latency=\"$LATENCY\"" "$SCENARIO_FILE"
+fi
+if [[ -n "$LOSS" ]]; then
+    # loss is digits-only (no % symbol) — stored as a YAML string per the model
+    yq -i ".[0].loss=\"$LOSS\"" "$SCENARIO_FILE"
+fi
+if [[ -n "$BANDWIDTH" ]]; then
+    yq -i ".[0].bandwidth=\"$BANDWIDTH\"" "$SCENARIO_FILE"
+fi
+
+# ── 4. Derive ingress / egress booleans from TRAFFIC_TYPE ────────────────────
+# TRAFFIC_TYPE is a string like "[egress]" or "[ingress,egress]".
+# We search for the word (case-insensitive) to derive each boolean.
+if echo "$TRAFFIC_TYPE" | grep -qi "ingress"; then
+    yq -i ".[0].ingress=true"  "$SCENARIO_FILE"
+else
+    yq -i ".[0].ingress=false" "$SCENARIO_FILE"
+fi
+
+if echo "$TRAFFIC_TYPE" | grep -qi "egress"; then
+    yq -i ".[0].egress=true"  "$SCENARIO_FILE"
+else
+    yq -i ".[0].egress=false" "$SCENARIO_FILE"
+fi
+
+# ── 5. List fields — interfaces and taints ────────────────────────────────────
+# INTERFACES and TAINTS are YAML array strings, e.g. "[]" or "[br-ex,eth0]".
+# yq accepts raw YAML expressions, so we pass the value directly.
+yq -i ".[0].interfaces=$INTERFACES" "$SCENARIO_FILE"
+yq -i ".[0].taints=$TAINTS"         "$SCENARIO_FILE"
+
+# ── 6. Generate krkn config.yaml ─────────────────────────────────────────────
+# The config.yaml.template references $SCENARIO_TYPE and $SCENARIO_FILE.
+# These two variables are what krkn's run_kraken.py reads to find our scenario.
+export SCENARIO_TYPE="network_chaos_ng_scenarios"
+export SCENARIO_FILE="$SCENARIO_FILE"
+envsubst < "$CONFIG_TEMPLATE" > "$CONFIG_OUT"
+
+# ── 7. Pre-flight check ───────────────────────────────────────────────────────
+# checks() is defined in common_run.sh — verifies kubectl/oc and kubeconfig.
+checks
+
+# ── 8. Debug output ───────────────────────────────────────────────────────────
+if [[ "$KRKN_DEBUG" == "True" ]]; then
+    echo "=== Scenario YAML ==="
+    cat "$SCENARIO_FILE"
+    echo "=== Krkn Config ==="
+    cat "$CONFIG_OUT"
+fi
+
+# ── 9. Run krkn ──────────────────────────────────────────────────────────────
+cd "$KRAKEN_FOLDER"
+exec python3.11 run_kraken.py --config="$CONFIG_OUT"


### PR DESCRIPTION
Adds the node-network-chaos scenario image for the NG node-level network chaos module.

- Dockerfile.template: inherits from krkn:latest, sets krknctl labels
- env.sh: default values for all NetworkChaosConfig fields
- run.sh: orchestrates input and executes krkn
- krknctl-input.json: 15 input fields matching the issue spec
- node-network-chaos.yml: seed YAML matching NetworkChaosConfig schema

Closes krkn-chaos/krkn#1452

## Description  
<!-- Provide a brief description of the changes made in this PR. -->  

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/). 

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  