### PR TITLE
feat: expose krkn event-driven command triggers via shared env

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,24 @@
+name: Unit Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    name: Run lightweight unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install gettext (envsubst)
+        run: sudo apt-get update && sudo apt-get install -y gettext-base
+
+      - name: Run triggers config unit test
+        run: bash CI/tests/test_triggers_config.sh

--- a/CI/tests/test_triggers_config.sh
+++ b/CI/tests/test_triggers_config.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Lightweight unit test: verify trigger env vars render into config.yaml correctly.
+# No cluster or container required. Requires envsubst (gettext).
+# Match other CI scripts: avoid nounset because env.sh references optional unset passwords.
+set -eo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+if ! command -v envsubst >/dev/null 2>&1; then
+  echo "FAIL: envsubst not found (install gettext)" >&2
+  exit 1
+fi
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# Render config.yaml.template with optional trigger env overrides in an isolated subshell.
+render() {
+  (
+    set -a
+    unset TRIGGER_COMMAND TRIGGER_EXPECTED_RC TRIGGERS_MODE \
+      TRIGGERS_TIMEOUT TRIGGERS_INTERVAL TRIGGERS_ON_TIMEOUT TRIGGERS_BLOCK \
+      RESILIENCY_SCORE DISABLE_RESILIENCY_SCORE
+    # Apply case-specific exports, then source shared defaults / TRIGGERS_BLOCK builder.
+    eval "$@"
+    # shellcheck disable=SC1091
+    source "$ROOT/env.sh"
+    envsubst < "$ROOT/config.yaml.template"
+  )
+}
+
+# Case 1: TRIGGER_COMMAND unset → no triggers block (backward compatible)
+out="$(render true)"
+if echo "$out" | grep -q '^triggers:'; then
+  fail "triggers present when TRIGGER_COMMAND is unset"
+fi
+
+# Case 2: TRIGGER_COMMAND set → triggers block with quoted string fields and values
+out="$(
+  render "export TRIGGER_COMMAND='kubectl get ns default'; \
+          export TRIGGERS_MODE='any_of'; \
+          export TRIGGERS_ON_TIMEOUT='fail'; \
+          export TRIGGERS_TIMEOUT='120'; \
+          export TRIGGERS_INTERVAL='7'; \
+          export TRIGGER_EXPECTED_RC='0'"
+)"
+echo "$out" | grep -q '^triggers:' || fail "triggers missing when TRIGGER_COMMAND is set"
+echo "$out" | grep -q 'mode: "any_of"' || fail "mode not rendered/quoted as expected"
+echo "$out" | grep -q 'on_timeout: "fail"' || fail "on_timeout not rendered/quoted as expected"
+echo "$out" | grep -q 'timeout: 120' || fail "timeout not rendered"
+echo "$out" | grep -q 'interval: 7' || fail "interval not rendered"
+echo "$out" | grep -q 'expected_rc: 0' || fail "expected_rc not rendered"
+echo "$out" | grep -q 'kubectl get ns default' || fail "command not inlined into triggers block"
+
+echo "PASS: triggers config rendering"

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -80,3 +80,5 @@ kubevirt_checks:                                            # Utilizing virt che
 resiliency:
   resiliency_run_mode: $RESILIENCY_RUN_MODE
   resiliency_file: $RESILIENCY_FILE
+
+$TRIGGERS_BLOCK

--- a/env.sh
+++ b/env.sh
@@ -80,3 +80,30 @@ export RESILIENCY_RUN_MODE=${RESILIENCY_RUN_MODE:="standalone"}
 export RESILIENCY_RUN_MODE=$([ "$RESILIENCY_SCORE" = "true" ] && echo "detailed" || echo "standalone")
 export RESILIENCY_RUN_MODE=$([ "$DISABLE_RESILIENCY_SCORE" = "true" ] && echo "disabled" || echo "$RESILIENCY_RUN_MODE")
 export RESILIENCY_FILE=${RESILIENCY_FILE:=$ALERTS_PATH}
+
+# chaos triggers (optional, backward compatible when TRIGGER_COMMAND is empty)
+export TRIGGER_COMMAND=${TRIGGER_COMMAND:=""}
+export TRIGGER_EXPECTED_RC=${TRIGGER_EXPECTED_RC:="0"}
+export TRIGGERS_MODE=${TRIGGERS_MODE:="all_of"}
+export TRIGGERS_TIMEOUT=${TRIGGERS_TIMEOUT:="300"}
+export TRIGGERS_INTERVAL=${TRIGGERS_INTERVAL:="5"}
+export TRIGGERS_ON_TIMEOUT=${TRIGGERS_ON_TIMEOUT:="skip"}
+
+# centralized config template block used by envsubst in config.yaml.template
+export TRIGGERS_BLOCK=""
+if [[ -n "$TRIGGER_COMMAND" ]]; then
+  TRIGGER_COMMAND_INDENTED=$(printf '%s\n' "$TRIGGER_COMMAND" | sed 's/^/        /')
+  export TRIGGERS_BLOCK=$(cat <<EOF
+triggers:
+  mode: "$TRIGGERS_MODE"
+  timeout: $TRIGGERS_TIMEOUT
+  interval: $TRIGGERS_INTERVAL
+  on_timeout: "$TRIGGERS_ON_TIMEOUT"
+  conditions:
+    - type: command
+      inline: |-
+$TRIGGER_COMMAND_INDENTED
+      expected_rc: $TRIGGER_EXPECTED_RC
+EOF
+)
+fi


### PR DESCRIPTION
## Summary
- Add optional shared trigger env vars in root `env.sh` and inject a top-level `triggers` block into `config.yaml.template` when `TRIGGER_COMMAND` is set.
- Keeps current behavior when unset (no `triggers` block), matching krkn Phase 1 command trigger support.

Related to https://github.com/krkn-chaos/krkn/issues/1483

## Test plan
- [x] Build local `pod-scenarios` image with patched krkn base that includes triggers
- [x] Run with example trigger (`kubectl get deploy nginx ... | grep -q 3`), confirm wait → scale to 3 → chaos inject → exit 0
- [ ] Confirm published `quay.io/krkn-chaos/krkn:latest` includes #1484 before relying on quay-only builds


Made with [Cursor](https://cursor.com)