### PR TITLE
feat: expose krkn event-driven http triggers via shared env

### DIFF
--- a/CI/tests/test_triggers_config.sh
+++ b/CI/tests/test_triggers_config.sh
@@ -23,6 +23,8 @@ render() {
     set -a
     unset TRIGGER_COMMAND TRIGGER_EXPECTED_RC TRIGGERS_MODE \
       TRIGGERS_TIMEOUT TRIGGERS_INTERVAL TRIGGERS_ON_TIMEOUT TRIGGERS_BLOCK \
+      TRIGGER_HTTP_URL TRIGGER_HTTP_METHOD TRIGGER_HTTP_EXPECTED_STATUS \
+      TRIGGER_HTTP_BEARER_TOKEN TRIGGER_HTTP_BODY_CONTAINS \
       RESILIENCY_SCORE DISABLE_RESILIENCY_SCORE
     # Apply case-specific exports, then source shared defaults / TRIGGERS_BLOCK builder.
     eval "$@"
@@ -54,5 +56,19 @@ echo "$out" | grep -q 'timeout: 120' || fail "timeout not rendered"
 echo "$out" | grep -q 'interval: 7' || fail "interval not rendered"
 echo "$out" | grep -q 'expected_rc: 0' || fail "expected_rc not rendered"
 echo "$out" | grep -q 'kubectl get ns default' || fail "command not inlined into triggers block"
+
+# Case 3: TRIGGER_HTTP_URL set -> HTTP block generated
+out="$(
+  render "export TRIGGER_HTTP_URL='http://example.com'; \
+          export TRIGGER_HTTP_EXPECTED_STATUS='201'; \
+          export TRIGGER_HTTP_BEARER_TOKEN='my-token'; \
+          export TRIGGER_HTTP_BODY_CONTAINS='ready'"
+)"
+echo "$out" | grep -q '^triggers:' || fail "triggers missing when TRIGGER_HTTP_URL is set"
+echo "$out" | grep -q 'type: http' || fail "type: http missing"
+echo "$out" | grep -q 'url: "http://example.com"' || fail "HTTP URL missing"
+echo "$out" | grep -q 'expected_status: 201' || fail "expected_status not rendered"
+echo "$out" | grep -q 'bearer_token: "my-token"' || fail "bearer_token not rendered"
+echo "$out" | grep -q 'body_contains: "ready"' || fail "body_contains not rendered"
 
 echo "PASS: triggers config rendering"

--- a/env.sh
+++ b/env.sh
@@ -71,9 +71,9 @@ export KUBE_VIRT_NAME=${KUBE_VIRT_NAME:=""}
 export KUBE_VIRT_LABEL_SELECTOR=${KUBE_VIRT_LABEL_SELECTOR:=""}
 export KUBE_VIRT_FAILURES=${KUBE_VIRT_FAILURES:=False}
 export KUBE_VIRT_DISCONNECTED=${KUBE_VIRT_DISCONNECTED:=False}
-export KUBE_VIRT_SSH_NODE=${KUBE_VIRT_SSH_NODE:""}
-export KUBE_VIRT_NODE_NAME=${KUBE_VIRT_NODE_NAME:""}                                     # Filter only VMI's running a specific node name
-export KUBE_VIRT_EXIT_ON_FAIL=${KUBE_VIRT_EXIT_ON_FAIL:False}
+export KUBE_VIRT_SSH_NODE=${KUBE_VIRT_SSH_NODE:=""}
+export KUBE_VIRT_NODE_NAME=${KUBE_VIRT_NODE_NAME:=""}                                     # Filter only VMI's running a specific node name
+export KUBE_VIRT_EXIT_ON_FAIL=${KUBE_VIRT_EXIT_ON_FAIL:=False}
 
 # resiliency score
 export RESILIENCY_RUN_MODE=${RESILIENCY_RUN_MODE:="standalone"}
@@ -84,6 +84,11 @@ export RESILIENCY_FILE=${RESILIENCY_FILE:=$ALERTS_PATH}
 # chaos triggers (optional, backward compatible when TRIGGER_COMMAND is empty)
 export TRIGGER_COMMAND=${TRIGGER_COMMAND:=""}
 export TRIGGER_EXPECTED_RC=${TRIGGER_EXPECTED_RC:="0"}
+export TRIGGER_HTTP_URL=${TRIGGER_HTTP_URL:=""}
+export TRIGGER_HTTP_METHOD=${TRIGGER_HTTP_METHOD:="GET"}
+export TRIGGER_HTTP_EXPECTED_STATUS=${TRIGGER_HTTP_EXPECTED_STATUS:="200"}
+export TRIGGER_HTTP_BEARER_TOKEN=${TRIGGER_HTTP_BEARER_TOKEN:=""}
+export TRIGGER_HTTP_BODY_CONTAINS=${TRIGGER_HTTP_BODY_CONTAINS:=""}
 export TRIGGERS_MODE=${TRIGGERS_MODE:="all_of"}
 export TRIGGERS_TIMEOUT=${TRIGGERS_TIMEOUT:="300"}
 export TRIGGERS_INTERVAL=${TRIGGERS_INTERVAL:="5"}
@@ -91,8 +96,7 @@ export TRIGGERS_ON_TIMEOUT=${TRIGGERS_ON_TIMEOUT:="skip"}
 
 # centralized config template block used by envsubst in config.yaml.template
 export TRIGGERS_BLOCK=""
-if [[ -n "$TRIGGER_COMMAND" ]]; then
-  TRIGGER_COMMAND_INDENTED=$(printf '%s\n' "$TRIGGER_COMMAND" | sed 's/^/        /')
+if [[ -n "$TRIGGER_COMMAND" ]] || [[ -n "$TRIGGER_HTTP_URL" ]]; then
   export TRIGGERS_BLOCK=$(cat <<EOF
 triggers:
   mode: "$TRIGGERS_MODE"
@@ -100,10 +104,43 @@ triggers:
   interval: $TRIGGERS_INTERVAL
   on_timeout: "$TRIGGERS_ON_TIMEOUT"
   conditions:
+EOF
+)
+
+  if [[ -n "$TRIGGER_COMMAND" ]]; then
+    TRIGGER_COMMAND_INDENTED=$(printf '%s\n' "$TRIGGER_COMMAND" | sed 's/^/        /')
+    export TRIGGERS_BLOCK=$(cat <<EOF
+$TRIGGERS_BLOCK
     - type: command
       inline: |-
 $TRIGGER_COMMAND_INDENTED
       expected_rc: $TRIGGER_EXPECTED_RC
 EOF
 )
+  fi
+
+  if [[ -n "$TRIGGER_HTTP_URL" ]]; then
+    export TRIGGERS_BLOCK=$(cat <<EOF
+$TRIGGERS_BLOCK
+    - type: http
+      url: "$TRIGGER_HTTP_URL"
+      method: "$TRIGGER_HTTP_METHOD"
+      expected_status: $TRIGGER_HTTP_EXPECTED_STATUS
+EOF
+)
+    if [[ -n "$TRIGGER_HTTP_BEARER_TOKEN" ]]; then
+      export TRIGGERS_BLOCK=$(cat <<EOF
+$TRIGGERS_BLOCK
+      bearer_token: "$TRIGGER_HTTP_BEARER_TOKEN"
+EOF
+)
+    fi
+    if [[ -n "$TRIGGER_HTTP_BODY_CONTAINS" ]]; then
+      export TRIGGERS_BLOCK=$(cat <<EOF
+$TRIGGERS_BLOCK
+      body_contains: "$TRIGGER_HTTP_BODY_CONTAINS"
+EOF
+)
+    fi
+  fi
 fi

--- a/env.sh
+++ b/env.sh
@@ -96,51 +96,37 @@ export TRIGGERS_ON_TIMEOUT=${TRIGGERS_ON_TIMEOUT:="skip"}
 
 # centralized config template block used by envsubst in config.yaml.template
 export TRIGGERS_BLOCK=""
-if [[ -n "$TRIGGER_COMMAND" ]] || [[ -n "$TRIGGER_HTTP_URL" ]]; then
-  export TRIGGERS_BLOCK=$(cat <<EOF
-triggers:
-  mode: "$TRIGGERS_MODE"
-  timeout: $TRIGGERS_TIMEOUT
-  interval: $TRIGGERS_INTERVAL
-  on_timeout: "$TRIGGERS_ON_TIMEOUT"
-  conditions:
-EOF
-)
+
+build_triggers_block() {
+  local block=""
+  block+="triggers:\n"
+  block+="  mode: \"$TRIGGERS_MODE\"\n"
+  block+="  timeout: $TRIGGERS_TIMEOUT\n"
+  block+="  interval: $TRIGGERS_INTERVAL\n"
+  block+="  on_timeout: \"$TRIGGERS_ON_TIMEOUT\"\n"
+  block+="  conditions:\n"
 
   if [[ -n "$TRIGGER_COMMAND" ]]; then
-    TRIGGER_COMMAND_INDENTED=$(printf '%s\n' "$TRIGGER_COMMAND" | sed 's/^/        /')
-    export TRIGGERS_BLOCK=$(cat <<EOF
-$TRIGGERS_BLOCK
-    - type: command
-      inline: |-
-$TRIGGER_COMMAND_INDENTED
-      expected_rc: $TRIGGER_EXPECTED_RC
-EOF
-)
+    local indented
+    indented=$(printf '%s\n' "$TRIGGER_COMMAND" | sed 's/^/        /')
+    block+="    - type: command\n"
+    block+="      inline: |-\n"
+    block+="$indented\n"
+    block+="      expected_rc: $TRIGGER_EXPECTED_RC\n"
   fi
 
   if [[ -n "$TRIGGER_HTTP_URL" ]]; then
-    export TRIGGERS_BLOCK=$(cat <<EOF
-$TRIGGERS_BLOCK
-    - type: http
-      url: "$TRIGGER_HTTP_URL"
-      method: "$TRIGGER_HTTP_METHOD"
-      expected_status: $TRIGGER_HTTP_EXPECTED_STATUS
-EOF
-)
-    if [[ -n "$TRIGGER_HTTP_BEARER_TOKEN" ]]; then
-      export TRIGGERS_BLOCK=$(cat <<EOF
-$TRIGGERS_BLOCK
-      bearer_token: "$TRIGGER_HTTP_BEARER_TOKEN"
-EOF
-)
-    fi
-    if [[ -n "$TRIGGER_HTTP_BODY_CONTAINS" ]]; then
-      export TRIGGERS_BLOCK=$(cat <<EOF
-$TRIGGERS_BLOCK
-      body_contains: "$TRIGGER_HTTP_BODY_CONTAINS"
-EOF
-)
-    fi
+    block+="    - type: http\n"
+    block+="      url: \"$TRIGGER_HTTP_URL\"\n"
+    block+="      method: \"$TRIGGER_HTTP_METHOD\"\n"
+    block+="      expected_status: $TRIGGER_HTTP_EXPECTED_STATUS\n"
+    [[ -n "$TRIGGER_HTTP_BEARER_TOKEN" ]] && block+="      bearer_token: \"$TRIGGER_HTTP_BEARER_TOKEN\"\n"
+    [[ -n "$TRIGGER_HTTP_BODY_CONTAINS" ]] && block+="      body_contains: \"$TRIGGER_HTTP_BODY_CONTAINS\"\n"
   fi
+
+  printf '%b' "$block"
+}
+
+if [[ -n "$TRIGGER_COMMAND" ]] || [[ -n "$TRIGGER_HTTP_URL" ]]; then
+  export TRIGGERS_BLOCK="$(build_triggers_block)"
 fi

--- a/env.sh
+++ b/env.sh
@@ -71,9 +71,9 @@ export KUBE_VIRT_NAME=${KUBE_VIRT_NAME:=""}
 export KUBE_VIRT_LABEL_SELECTOR=${KUBE_VIRT_LABEL_SELECTOR:=""}
 export KUBE_VIRT_FAILURES=${KUBE_VIRT_FAILURES:=False}
 export KUBE_VIRT_DISCONNECTED=${KUBE_VIRT_DISCONNECTED:=False}
-export KUBE_VIRT_SSH_NODE=${KUBE_VIRT_SSH_NODE:=""}
-export KUBE_VIRT_NODE_NAME=${KUBE_VIRT_NODE_NAME:=""}                                     # Filter only VMI's running a specific node name
-export KUBE_VIRT_EXIT_ON_FAIL=${KUBE_VIRT_EXIT_ON_FAIL:=False}
+export KUBE_VIRT_SSH_NODE=${KUBE_VIRT_SSH_NODE:""}
+export KUBE_VIRT_NODE_NAME=${KUBE_VIRT_NODE_NAME:""}                                     # Filter only VMI's running a specific node name
+export KUBE_VIRT_EXIT_ON_FAIL=${KUBE_VIRT_EXIT_ON_FAIL:False}
 
 # resiliency score
 export RESILIENCY_RUN_MODE=${RESILIENCY_RUN_MODE:="standalone"}


### PR DESCRIPTION
Wires the new HTTP trigger type (from `krkn` core PR) into config.yaml.template so hub scenarios can natively poll an HTTP endpoint before chaos injection.

- `env.sh`: adds `TRIGGER_HTTP_*` defaults and dynamically renders the `TRIGGERS_BLOCK` if an HTTP URL is provided.
- `CI/tests/test_triggers_config.sh`: adds unit tests for HTTP trigger rendering.

Related to krkn-chaos/krkn#1498

### Type of change
- [x] New feature
