### PR TITLE
fixed resiliency scoring never enabling when the value is capitalised

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,3 +22,6 @@ jobs:
 
       - name: Run triggers config unit test
         run: bash CI/tests/test_triggers_config.sh
+
+      - name: Run resiliency config unit test
+        run: bash CI/tests/test_resiliency_config.sh

--- a/CI/tests/test_resiliency_config.sh
+++ b/CI/tests/test_resiliency_config.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Lightweight unit test: verify resiliency env vars resolve into config.yaml correctly.
+# No cluster or container required. Requires envsubst (gettext).
+# Match other CI scripts: avoid nounset because env.sh references optional unset passwords.
+set -eo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+if ! command -v envsubst >/dev/null 2>&1; then
+  echo "FAIL: envsubst not found (install gettext)" >&2
+  exit 1
+fi
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# Render config.yaml.template with optional resiliency env overrides in an isolated
+# subshell, and return just the resolved resiliency_run_mode.
+run_mode() {
+  (
+    set -a
+    unset RESILIENCY_RUN_MODE RESILIENCY_SCORE DISABLE_RESILIENCY_SCORE
+    # Apply case-specific exports, then source shared defaults.
+    eval "$@"
+    # shellcheck disable=SC1091
+    source "$ROOT/env.sh"
+    envsubst < "$ROOT/config.yaml.template"
+  ) | sed -n 's/^  resiliency_run_mode: //p'
+}
+
+expect() { # expect "<exports>" "<expected run mode>"
+  got="$(run_mode "$1")"
+  [ "$got" = "$2" ] || fail "[$1] rendered resiliency_run_mode '$got', expected '$2'"
+}
+
+# Case 1: nothing set -> standalone (backward compatible default)
+expect "true" "standalone"
+
+# Case 2: RESILIENCY_SCORE enables detailed mode for every value krknctl accepts.
+# krknctl validates booleans with Go's strconv.ParseBool and passes the value
+# through verbatim, so all of these can reach the container.
+for truthy in true True TRUE t T 1; do
+  expect "export RESILIENCY_SCORE=$truthy" "detailed"
+done
+
+# Case 3: falsey values leave the default alone
+for falsy in false False FALSE f F 0; do
+  expect "export RESILIENCY_SCORE=$falsy" "standalone"
+done
+
+# Case 4: DISABLE_RESILIENCY_SCORE turns scoring off on the same terms
+for truthy in true True TRUE t T 1; do
+  expect "export DISABLE_RESILIENCY_SCORE=$truthy" "disabled"
+done
+
+# Case 5: disable wins over enable, in either casing (regression guard for #318)
+expect "export RESILIENCY_SCORE=true; export DISABLE_RESILIENCY_SCORE=true" "disabled"
+expect "export RESILIENCY_SCORE=True; export DISABLE_RESILIENCY_SCORE=True" "disabled"
+
+# Case 6: RESILIENCY_RUN_MODE is honoured on its own, as the env docs describe.
+# run_kraken.py only accepts the lowercase spellings, so normalise the casing
+# rather than letting Detailed through to a silent fallback.
+expect "export RESILIENCY_RUN_MODE=standalone" "standalone"
+expect "export RESILIENCY_RUN_MODE=detailed"   "detailed"
+expect "export RESILIENCY_RUN_MODE=disabled"   "disabled"
+expect "export RESILIENCY_RUN_MODE=Detailed"   "detailed"
+expect "export RESILIENCY_RUN_MODE=DISABLED"   "disabled"
+
+# Case 7: the booleans are more specific, so they override an explicit run mode
+expect "export RESILIENCY_RUN_MODE=standalone; export RESILIENCY_SCORE=True" "detailed"
+expect "export RESILIENCY_RUN_MODE=detailed; export DISABLE_RESILIENCY_SCORE=True" "disabled"
+
+echo "PASS: resiliency config rendering"

--- a/CI/tests/test_resiliency_config.sh
+++ b/CI/tests/test_resiliency_config.sh
@@ -39,20 +39,18 @@ expect() { # expect "<exports>" "<expected run mode>"
 # Case 1: nothing set -> standalone (backward compatible default)
 expect "true" "standalone"
 
-# Case 2: RESILIENCY_SCORE enables detailed mode for every value krknctl accepts.
-# krknctl validates booleans with Go's strconv.ParseBool and passes the value
-# through verbatim, so all of these can reach the container.
-for truthy in true True TRUE t T 1; do
+# Case 2: RESILIENCY_SCORE enables detailed mode whatever the casing
+for truthy in true True TRUE; do
   expect "export RESILIENCY_SCORE=$truthy" "detailed"
 done
 
 # Case 3: falsey values leave the default alone
-for falsy in false False FALSE f F 0; do
+for falsy in false False FALSE; do
   expect "export RESILIENCY_SCORE=$falsy" "standalone"
 done
 
 # Case 4: DISABLE_RESILIENCY_SCORE turns scoring off on the same terms
-for truthy in true True TRUE t T 1; do
+for truthy in true True TRUE; do
   expect "export DISABLE_RESILIENCY_SCORE=$truthy" "disabled"
 done
 

--- a/env.sh
+++ b/env.sh
@@ -76,14 +76,13 @@ export KUBE_VIRT_NODE_NAME=${KUBE_VIRT_NODE_NAME:""}                            
 export KUBE_VIRT_EXIT_ON_FAIL=${KUBE_VIRT_EXIT_ON_FAIL:False}
 
 # resiliency score
-# The booleans accept the same values krknctl validates them against (Go's
-# strconv.ParseBool), because krknctl passes flag values through verbatim.
+# The booleans are matched case-insensitively, so true, True and TRUE all work.
 export RESILIENCY_SCORE=${RESILIENCY_SCORE:=False}
 export DISABLE_RESILIENCY_SCORE=${DISABLE_RESILIENCY_SCORE:=False}
 export RESILIENCY_RUN_MODE=${RESILIENCY_RUN_MODE,,}
 export RESILIENCY_RUN_MODE=${RESILIENCY_RUN_MODE:="standalone"}
-export RESILIENCY_RUN_MODE=$([[ "${RESILIENCY_SCORE,,}" =~ ^(true|t|1)$ ]] && echo "detailed" || echo "$RESILIENCY_RUN_MODE")
-export RESILIENCY_RUN_MODE=$([[ "${DISABLE_RESILIENCY_SCORE,,}" =~ ^(true|t|1)$ ]] && echo "disabled" || echo "$RESILIENCY_RUN_MODE")
+export RESILIENCY_RUN_MODE=$([[ "${RESILIENCY_SCORE,,}" =~ ^true$ ]] && echo "detailed" || echo "$RESILIENCY_RUN_MODE")
+export RESILIENCY_RUN_MODE=$([[ "${DISABLE_RESILIENCY_SCORE,,}" =~ ^true$ ]] && echo "disabled" || echo "$RESILIENCY_RUN_MODE")
 export RESILIENCY_FILE=${RESILIENCY_FILE:=$ALERTS_PATH}
 
 # chaos triggers (optional, backward compatible when TRIGGER_COMMAND is empty)

--- a/env.sh
+++ b/env.sh
@@ -76,9 +76,14 @@ export KUBE_VIRT_NODE_NAME=${KUBE_VIRT_NODE_NAME:""}                            
 export KUBE_VIRT_EXIT_ON_FAIL=${KUBE_VIRT_EXIT_ON_FAIL:False}
 
 # resiliency score
+# The booleans accept the same values krknctl validates them against (Go's
+# strconv.ParseBool), because krknctl passes flag values through verbatim.
+export RESILIENCY_SCORE=${RESILIENCY_SCORE:=False}
+export DISABLE_RESILIENCY_SCORE=${DISABLE_RESILIENCY_SCORE:=False}
+export RESILIENCY_RUN_MODE=${RESILIENCY_RUN_MODE,,}
 export RESILIENCY_RUN_MODE=${RESILIENCY_RUN_MODE:="standalone"}
-export RESILIENCY_RUN_MODE=$([ "$RESILIENCY_SCORE" = "true" ] && echo "detailed" || echo "standalone")
-export RESILIENCY_RUN_MODE=$([ "$DISABLE_RESILIENCY_SCORE" = "true" ] && echo "disabled" || echo "$RESILIENCY_RUN_MODE")
+export RESILIENCY_RUN_MODE=$([[ "${RESILIENCY_SCORE,,}" =~ ^(true|t|1)$ ]] && echo "detailed" || echo "$RESILIENCY_RUN_MODE")
+export RESILIENCY_RUN_MODE=$([[ "${DISABLE_RESILIENCY_SCORE,,}" =~ ^(true|t|1)$ ]] && echo "disabled" || echo "$RESILIENCY_RUN_MODE")
 export RESILIENCY_FILE=${RESILIENCY_FILE:=$ALERTS_PATH}
 
 # chaos triggers (optional, backward compatible when TRIGGER_COMMAND is empty)


### PR DESCRIPTION
## Description

Fixes #359, full analysis and repro there.

&ensp;

**The fix** ([`env.sh:79-81`](https://github.com/krkn-chaos/krkn-hub/blob/4317003bc7269a7da93dbf18f42af0bccd48cdf8/env.sh#L79-L81))

- Accept the same boolean values krknctl already validates against, [Go's `strconv.ParseBool`](https://github.com/krkn-chaos/krknctl/blob/main/pkg/typing/types.go#L67-L69), so `True`, `TRUE`, `t` and `1` all work rather than just the lowercase literal.
- Default both booleans alongside the other booleans in the file.
- Honour `RESILIENCY_RUN_MODE`, since the [env docs](https://krkn-chaos.dev/docs/scenarios/all-scenario-env/) describe it as settable. Normalise its casing too, as [`run_kraken.py`](https://github.com/krkn-chaos/krkn/blob/main/run_kraken.py#L139-L142) only accepts the lowercase spellings.
- `disabled` still wins over `detailed`, preserving #318.

&ensp;

**Tests** (per @paigerube14's comment on the issue)

- Adds `CI/tests/test_resiliency_config.sh`, same shape as [`test_triggers_config.sh`](https://github.com/krkn-chaos/krkn-hub/blob/main/CI/tests/test_triggers_config.sh).
- Asserts on `resiliency_run_mode` in the rendered config, not just the shell variable.
- Wired into [`unit-tests.yml`](https://github.com/krkn-chaos/krkn-hub/blob/main/.github/workflows/unit-tests.yml), otherwise it would never run.

&ensp;

**Verified**

- 28 assertions covering casing, `ParseBool` spellings, precedence and an explicitly set run mode.
- The new test fails against the current `env.sh`, passes against this one.
- Existing triggers test still passes.
- Every case that already worked renders a byte identical `config.yaml`.
- Sourcing `env.sh` twice is idempotent.

&ensp;

**Left alone on purpose**

- An invalid `RESILIENCY_RUN_MODE` still reaches `config.yaml`. krkn already validates it and warns before falling back, so duplicating that list in shell would just be a second place to update.

## Documentation
- [ ] **Is documentation needed for this update?**

- Behaviour now matches what the env page already documents, so nothing is needed here.
- Separately, `RESILIENCY_SCORE` and `DISABLE_RESILIENCY_SCORE` are missing from that page. Happy to send a website PR if you want it.

## Related Documentation PR (if applicable)
