### PR TITLE
add generate_report_pdf parameter

### DIFF
--- a/config.yaml.template
+++ b/config.yaml.template
@@ -5,6 +5,7 @@ kraken:
     publish_kraken_status: $PUBLISH_KRAKEN_STATUS
     signal_state: $SIGNAL_STATE                            # Will wait for the RUN signal when set to PAUSE before running the scenarios
     signal_address: $SIGNAL_ADDRESS                        # Signal listening address
+    generate_pdf_report: $GENERATE_PDF_REPORT
     chaos_scenarios:                                       # List of policies/chaos scenarios to load
         - $SCENARIO_TYPE:                                  # List of chaos time scenarios to load
             - $SCENARIO_FILE

--- a/env.sh
+++ b/env.sh
@@ -19,6 +19,7 @@ export CAPTURE_METRICS=${CAPTURE_METRICS:=False}
 export ENABLE_ALERTS=${ENABLE_ALERTS:=False}
 export ALERTS_PATH=${ALERTS_PATH:=config/alerts.yaml}
 export METRICS_PATH=${METRICS_PATH:=config/metrics-aggregated.yaml}
+export GENERATE_PDF_REPORT=${GENERATE_PDF_REPORT:=True}
 
 export ENABLE_ES=${ENABLE_ES:=False}
 export ES_SERVER=${ES_SERVER:=http://0.0.0.0}


### PR DESCRIPTION
## Description  
 Added generate_pdf_report config field to the kraken section of config.yaml.template and its corresponding environment variable default in env.sh. This supports the new PDF summary report feature added in krkn.

## Documentation  
- [x] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/). 

## Related Documentation PR (if applicable)  
TODO: https://github.com/krkn-chaos/website/blob/main/content/en/docs/krkn/config.md