### PR TITLE
align krknctl-input descriptions with the published docs (#363)

### DIFF
--- a/application-outages/krknctl-input.json
+++ b/application-outages/krknctl-input.json
@@ -29,7 +29,7 @@
     {
         "name": "exclude-selector",
         "short_description": "Exclude Pod Selector",
-        "description": "Pods to exclude from targetting. For example \"{app: foo}\"",
+        "description": "Pods to exclude after using pod-selector to target. For example \"{app: foo}\"",
         "type": "string",
         "variable": "EXCLUDE_LABEL",
         "validator": "\\{[a-zA-Z0-9-_]+\\: [a-zA-Z0-9-_]+\\}",

--- a/container-scenarios/krknctl-input.json
+++ b/container-scenarios/krknctl-input.json
@@ -32,7 +32,7 @@
     {
         "name": "disruption-count",
         "short_description": "Disruption Count",
-        "description": "Number of container to disrupt",
+        "description": "Number of containers to disrupt",
         "type": "number",
         "variable": "DISRUPTION_COUNT",
         "default": "1",

--- a/kubevirt-outage/krknctl-input.json
+++ b/kubevirt-outage/krknctl-input.json
@@ -38,7 +38,7 @@
     {
         "name": "kill-count",
         "short_description": "Kill Count",
-        "description": "Number of VMs to kill",
+        "description": "Number of VMIs to kill (performed serially)",
         "variable": "KILL_COUNT",
         "type": "number",
         "default": "1",

--- a/network-chaos/krknctl-input.json
+++ b/network-chaos/krknctl-input.json
@@ -12,7 +12,7 @@
     {
         "name": "image",
         "short_description": "Image",
-        "description": "Network chaos helper image",
+        "description": "Image used to disrupt network on a pod",
         "variable": "IMAGE",
         "type": "string",
         "default": "quay.io/krkn-chaos/krkn:tools",

--- a/node-cpu-hog/krknctl-input.json
+++ b/node-cpu-hog/krknctl-input.json
@@ -2,7 +2,7 @@
     {
 	   "name":"chaos-duration",
        	"short_description":"Chaos Duration",
-        "description":"Set chaos duration (in sec) as desired",
+        "description":"Set chaos duration (in secs) as desired",
         "variable":"TOTAL_CHAOS_DURATION",
         "type":"number",
         "default":"60"
@@ -44,7 +44,7 @@
      {
         "name":"taints",
 	    "short_description":"Node Taints",
-        "description":"List of taints for which tolerations need to created. For example [\"node-role.kubernetes.io/master:NoSchedule\"]",
+        "description":"List of taints for which tolerations need to be created. For example [\"node-role.kubernetes.io/master:NoSchedule\"]",
         "variable":"TAINTS",
         "type":"string",
         "default":"[]",

--- a/node-io-hog/krknctl-input.json
+++ b/node-io-hog/krknctl-input.json
@@ -67,7 +67,7 @@
      {
         "name":"taints",
 	    "short_description":"Node Taints",
-        "description":"List of taints for which tolerations need to created. For example [\"node-role.kubernetes.io/master:NoSchedule\"]",
+        "description":"List of taints for which tolerations need to be created. For example [\"node-role.kubernetes.io/master:NoSchedule\"]",
         "variable":"TAINTS",
         "type":"string",
         "default":"[]",

--- a/node-memory-hog/krknctl-input.json
+++ b/node-memory-hog/krknctl-input.json
@@ -48,7 +48,7 @@
      {
         "name":"taints",
 	    "short_description":"Node Taints",
-        "description":"List of taints for which tolerations need to created. For example [\"node-role.kubernetes.io/master:NoSchedule\"]",
+        "description":"List of taints for which tolerations need to be created. For example [\"node-role.kubernetes.io/master:NoSchedule\"]",
         "variable":"TAINTS",
         "type":"string",
         "default":"[]",

--- a/node-network-chaos/krknctl-input.json
+++ b/node-network-chaos/krknctl-input.json
@@ -11,7 +11,7 @@
   {
     "name": "node-name",
     "short_description": "Target node name",
-    "description": "Exact node name to target when label-selector is not specified.",
+    "description": "Exact node name to target when --label-selector is not specified",
     "variable": "NODE_NAME",
     "type": "string",
     "default": "",
@@ -20,7 +20,7 @@
   {
     "name": "instance-count",
     "short_description": "Number of nodes to target",
-    "description": "How many nodes matching the selector to apply chaos on simultaneously.",
+    "description": "Number of nodes matching the selector to apply chaos on simultaneously",
     "variable": "INSTANCE_COUNT",
     "type": "number",
     "default": "1",
@@ -47,7 +47,7 @@
   {
     "name": "latency",
     "short_description": "Network latency to inject",
-    "description": "Artificial delay to add to matching packets. Format: <number><unit> where unit is us, ms, or s (e.g. 200ms).",
+    "description": "Artificial delay to add to matching packets. Format: <number><unit> where unit is us, ms, or s (e.g. 200ms). Leave empty to skip",
     "variable": "LATENCY",
     "type": "string",
     "default": "",
@@ -56,7 +56,7 @@
   {
     "name": "loss",
     "short_description": "Packet loss percentage",
-    "description": "Percentage of packets to drop. Digits only, no % symbol (e.g. 10 means 10%).",
+    "description": "Percentage of packets to drop. Digits only, no % symbol (e.g. 10 means 10%). Leave empty to skip",
     "variable": "LOSS",
     "type": "string",
     "default": "",
@@ -65,7 +65,7 @@
   {
     "name": "bandwidth",
     "short_description": "Bandwidth limit",
-    "description": "Maximum throughput for matching traffic. Format: <number><unit> where unit is bit, kbit, mbit, gbit, or tbit (e.g. 100mbit).",
+    "description": "Maximum throughput for matching traffic. Format: <number><unit> where unit is bit, kbit, mbit, gbit, or tbit (e.g. 100mbit). Leave empty to skip",
     "variable": "BANDWIDTH",
     "type": "string",
     "default": "",
@@ -94,7 +94,7 @@
   {
     "name": "force",
     "short_description": "Force qdisc replacement",
-    "description": "When true, removes any pre-existing tc qdiscs on the interface before applying new rules.",
+    "description": "When true, removes any pre-existing tc qdiscs on the interface before applying new rules. Use with caution",
     "variable": "FORCE",
     "type": "enum",
     "allowed_values": "true,false",

--- a/node-network-filter/krknctl-input.json
+++ b/node-network-filter/krknctl-input.json
@@ -22,7 +22,7 @@
   {
     "name": "node-name",
     "short_description": "Node Name",
-    "description": "The Node name to target (if label selector not specified)",
+    "description": "Specific node name to target (alternative to node-selector)",
     "variable": "NODE_NAME",
     "type": "string",
     "default": "",
@@ -76,7 +76,7 @@
   {
     "name": "interfaces",
     "short_description": "Network interfaces to filter outgoing traffic (if more than one separated by comma)",
-    "description": "Network interfaces to filter outgoing traffic (if more than one separated by comma eg. eth0,eth1,eth2)",
+    "description": "Network interfaces for outgoing traffic (comma-separated, e.g. eth0,eth1). Optional, empty uses workload defaults",
     "variable": "INTERFACES",
     "type": "string",
     "default": "",
@@ -117,7 +117,7 @@
   {
     "name": "taints",
     "short_description": "The list of tolerations that can be assigned to the network filter workload",
-    "description": "The list of tolerations that can be assigned to the network filter workload (comma separated)",
+    "description": "Comma-separated taints for which tolerations are derived for the workload, e.g. node-role.kubernetes.io/master:NoSchedule",
     "variable": "TAINTS",
     "type": "string",
     "default": "",

--- a/node-scenarios-bm/krknctl-input.json
+++ b/node-scenarios-bm/krknctl-input.json
@@ -2,7 +2,7 @@
     {
         "name":"scenario-file-path",
         "short_description":"Scenario file path",
-        "description": "The absolute path of the scenario file compiled following the documentation",
+        "description": "Absolute path to the baremetal node-scenarios YAML file. krknctl base64-encodes it and supplies it as SCENARIO_BASE64 to the container",
         "variable": "SCENARIO_BASE64",
         "type": "file_base64",
         "required": "true"

--- a/node-scenarios/krknctl-input.json
+++ b/node-scenarios/krknctl-input.json
@@ -245,7 +245,7 @@
     {
         "name": "disable-ssl-verification",
         "short_description": "Disable SSL Verification [*IBM Cloud only*]",
-        "description": "Disable SSL certificate verification",
+        "description": "Disable SSL verification, to avoid certificate errors",
         "variable": "DISABLE_SSL_VERIFICATION",
         "type": "enum",
         "allowed_values": "true,false,True,False",

--- a/pod-network-chaos/krknctl-input.json
+++ b/pod-network-chaos/krknctl-input.json
@@ -10,7 +10,7 @@
     {
         "name": "image",
         "short_description": "Image",
-        "description": "Network chaos helper image",
+        "description": "Image used to disrupt network on a pod",
         "variable": "IMAGE",
         "type": "string",
         "default": "quay.io/krkn-chaos/krkn:tools",
@@ -28,7 +28,7 @@
     {
         "name":"exclude-label",
 	    "short_description":"Pod exclude label",
-        "description":"Label for excluding one or more pods from chaos",
+        "description":"Pods matching this label will be excluded from the chaos even if they match other criteria",
         "variable":"EXCLUDE_LABEL",
         "type":"string",
         "default":"",

--- a/pod-network-filter/krknctl-input.json
+++ b/pod-network-filter/krknctl-input.json
@@ -117,7 +117,7 @@
   {
     "name": "taints",
     "short_description": "The list of tolerations that can be assigned to the network filter workload",
-    "description": "The list of tolerations that can be assigned to the network filter workload (comma separated)",
+    "description": "Comma-separated taints for which tolerations are derived for the workload, e.g. node-role.kubernetes.io/master:NoSchedule",
     "variable": "TAINTS",
     "type": "string",
     "default": "",

--- a/pod-scenarios/krknctl-input.json
+++ b/pod-scenarios/krknctl-input.json
@@ -11,7 +11,7 @@
     {
         "name": "node-names",
         "short_description": "Node names",
-        "description": "Node names to target",
+        "description": "Name of the node(s) to target. Example: [\"worker-node-1\",\"worker-node-2\",\"master-node-1\"]",
         "variable": "NODE_NAMES",
         "type": "string",
         "default": "",
@@ -29,7 +29,7 @@
     {
         "name": "pod-label",
         "short_description": "Pod label",
-        "description": "Label of the pod(s) to target",
+        "description": "Label of the pod(s) to target ex. \"app=test\"",
         "variable": "POD_LABEL",
         "type": "string",
         "default": "",
@@ -38,7 +38,7 @@
     {
         "name": "exclude-label",
         "short_description": "Pod exclude label",
-        "description": "Label for excluding one or more pods from chaos",
+        "description": "Pods matching this label will be excluded from the chaos even if they match other criteria",
         "variable": "EXCLUDE_LABEL",
         "type": "string",
         "default": "",

--- a/power-outages/krknctl-input.json
+++ b/power-outages/krknctl-input.json
@@ -11,7 +11,7 @@
     {
         "name": "cloud-type",
         "short_description": "Cloud Type",
-        "description": "Cloud platform on top of which cluster is running",
+        "description": "Cloud platform on top of which cluster is running, supported platforms - aws, azure, gcp, vmware, ibmcloud, bm",
         "variable": "CLOUD_TYPE",
         "type": "enum",
         "allowed_values": "aws,azure,gcp,vmware,ibmcloud,bm",

--- a/storage-throttle/krknctl-input.json
+++ b/storage-throttle/krknctl-input.json
@@ -2,7 +2,7 @@
   {
     "name": "pvc-name",
     "short_description": "PVC name",
-    "description": "Target PVC name. If set, pod_name is auto-resolved from PVC",
+    "description": "Target PVC name. If set, --pod-name is auto-resolved from PVC",
     "variable": "PVC_NAME",
     "type": "string",
     "default": "",
@@ -11,7 +11,7 @@
   {
     "name": "pod-name",
     "short_description": "Pod name",
-    "description": "Target pod name. Ignored if PVC_NAME is set",
+    "description": "Target pod name. Ignored if --pvc-name is set",
     "variable": "POD_NAME",
     "type": "string",
     "default": "",
@@ -29,7 +29,7 @@
   {
     "name": "mount-path",
     "short_description": "Mount path",
-    "description": "Specific mount path to throttle (optional)",
+    "description": "Specific mount path to throttle (absolute path, example: /data)",
     "variable": "MOUNT_PATH",
     "type": "string",
     "validator": "^$|^/[a-zA-Z0-9._/\\-]+$",
@@ -40,7 +40,7 @@
   {
     "name": "throttle-type",
     "short_description": "Throttle mode",
-    "description": "Throttle mode to apply",
+    "description": "Throttle mode to apply (bandwidth, iops, both)",
     "variable": "THROTTLE_TYPE",
     "type": "enum",
     "allowed_values": "bandwidth,iops,both",

--- a/time-scenarios/krknctl-input.json
+++ b/time-scenarios/krknctl-input.json
@@ -2,7 +2,7 @@
     {
         "name":"object-type",
         "short_description":"Object type",
-        "description":"Object to target. Supported options: pod, node",
+        "description":"Object to target. Supported options: pod or node",
         "variable":"OBJECT_TYPE",
         "type":"enum",
         "allowed_values":"pod,node",
@@ -22,7 +22,7 @@
     {
         "name":"action",
         "short_description":"Action",
-        "description":"Action to run. Supported actions: skew_time, skew_date",
+        "description":"Action to run. Supported actions: skew_time or skew_date",
         "variable":"ACTION",
         "type":"enum",
         "allowed_values":"skew_time,skew_date",

--- a/vmi-network-filter/krknctl-input.json
+++ b/vmi-network-filter/krknctl-input.json
@@ -117,7 +117,7 @@
   {
     "name": "taints",
     "short_description": "The list of tolerations for the network filter workload",
-    "description": "The list of tolerations that can be assigned to the network filter workload (comma separated)",
+    "description": "Comma-separated taints for which tolerations are created, e.g. node-role.kubernetes.io/master:NoSchedule",
     "variable": "TAINTS",
     "type": "string",
     "default": "",

--- a/zone-outages/krknctl-input.json
+++ b/zone-outages/krknctl-input.json
@@ -2,7 +2,7 @@
     {
         "name": "cloud-type",
         "short_description": "Cloud Type",
-        "description": "Cloud platform on top of which cluster is running",
+        "description": "Cloud platform on top of which cluster is running, supported platforms - aws, gcp",
         "variable": "CLOUD_TYPE",
         "type": "enum",
         "allowed_values": "aws,gcp",
@@ -72,7 +72,7 @@
     {
         "name": "zone",
         "short_description": "ZONE",
-        "description": "cluster zone to target",
+        "description": "cluster zone to target (only for gcp cloud type)",
         "variable": "ZONE",
         "type": "string",
         "default": "",


### PR DESCRIPTION
Fixes #363, the table of all 35 is in the issue.

Descriptions only, across 19 `krknctl-input.json` files. Nothing else changed, so no scenario behaves differently.

I checked each one against its current value before editing, and the diff is exactly 35 lines, one per flag. 
The formatting remains untouched.
