### PR TITLE
feat(pod-disruption): expose execution config parameter for parallel pod deletion

### DIFF
--- a/CI/tests/test_triggers_config.sh
+++ b/CI/tests/test_triggers_config.sh
@@ -102,4 +102,5 @@ if echo "$out" | grep -A5 'type: k8s' | grep -q 'namespace:'; then
   fail "namespace rendered in k8s block for cluster-scoped resource"
 fi
 
+
 echo "PASS: triggers config rendering"


### PR DESCRIPTION
## Description
This PR addresses the maintainer feedback on the core `krkn` repository by exposing the newly added `execution` parameter in `krkn-hub` and `krknctl`. 

Changes:
- Added `EXECUTION` variable to `pod-scenarios/env.sh` (defaults to `serial`).
- Updated `pod_scenario.yaml.template` and `pod_scenario_namespace.yaml.template` to map `$EXECUTION`.
- Updated `krknctl-input.json` to include the `--execution` flag for `krknctl` usage.

## Documentation
- [x] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)
https://github.com/krkn-chaos/website/pull/587
