### PR TITLE
fix vsphere descriptions in node-scenarios and power-outages

### DIFF
--- a/node-scenarios/krknctl-input.json
+++ b/node-scenarios/krknctl-input.json
@@ -111,7 +111,7 @@
     {
         "name": "vsphere-ip",
         "short_description": "VSphere IP [*VSphere only*]",
-        "description": "VSpere IP Address",
+        "description": "vSphere IP address",
         "variable": "VSPHERE_IP",
         "type": "string",
         "default": "",
@@ -120,7 +120,7 @@
     {
         "name": "vsphere-username",
         "short_description": "VSphere Username [*VSphere only*]",
-        "description": "VSpere IP Address",
+        "description": "vSphere username",
         "variable": "VSPHERE_USERNAME",
         "type": "string",
         "default": "",
@@ -130,7 +130,7 @@
     {
         "name": "vsphere-password",
         "short_description": "VSphere Password [*VSphere only*]",
-        "description": "VSpere password",
+        "description": "vSphere password",
         "variable": "VSPHERE_PASSWORD",
         "type": "string",
         "default": "",

--- a/power-outages/krknctl-input.json
+++ b/power-outages/krknctl-input.json
@@ -31,7 +31,7 @@
     {
         "name": "vsphere-ip",
         "short_description": "VSphere IP [*VSphere only*]",
-        "description": "VSpere IP Address",
+        "description": "vSphere IP address",
         "variable": "VSPHERE_IP",
         "type": "string",
         "default": "",
@@ -40,7 +40,7 @@
     {
         "name": "vsphere-username",
         "short_description": "VSphere Username [*VSphere only*]",
-        "description": "VSpere IP Address",
+        "description": "vSphere username",
         "variable": "VSPHERE_USERNAME",
         "type": "string",
         "default": "",
@@ -50,7 +50,7 @@
     {
         "name": "vsphere-password",
         "short_description": "VSphere Password [*VSphere only*]",
-        "description": "VSpere password",
+        "description": "vSphere password",
         "variable": "VSPHERE_PASSWORD",
         "type": "string",
         "default": "",


### PR DESCRIPTION
Fixes #365.

`vsphere-username` was describing an IP address in both files. Now it says what it is:

| flag | was | now |
| --- | --- | --- |
| `--vsphere-ip` | VSpere IP Address | vSphere IP address |
| `--vsphere-username` | VSpere IP Address | vSphere username |
| `--vsphere-password` | VSpere password | vSphere password |

Six lines, three in `node-scenarios/krknctl-input.json` and three in `power-outages/krknctl-input.json`. 
That is every `VSpere` left in the repo.

Completely description specific, other things are untouched.