### PR TITLE
feat: add prometheus trigger type to shared env config

### DIFF
--- a/CI/tests/test_triggers_config.sh
+++ b/CI/tests/test_triggers_config.sh
@@ -27,6 +27,7 @@ render() {
       TRIGGER_HTTP_BEARER_TOKEN TRIGGER_HTTP_BODY_CONTAINS \
       TRIGGER_K8S_API_VERSION TRIGGER_K8S_KIND TRIGGER_K8S_NAME \
       TRIGGER_K8S_NAMESPACE TRIGGER_K8S_CONDITION \
+      TRIGGER_PROM_QUERY TRIGGER_PROM_URL TRIGGER_PROM_TOKEN \
       RESILIENCY_SCORE DISABLE_RESILIENCY_SCORE
     # Apply case-specific exports, then source shared defaults / TRIGGERS_BLOCK builder.
     eval "$@"
@@ -100,6 +101,29 @@ echo "$out" | grep -q 'type: k8s' || fail "type: k8s missing for cluster-scoped 
 # Ensure no namespace line appears in the k8s trigger block (indented under type: k8s)
 if echo "$out" | grep -A5 'type: k8s' | grep -q 'namespace:'; then
   fail "namespace rendered in k8s block for cluster-scoped resource"
+fi
+
+# Case 6: TRIGGER_PROM_QUERY set -> prometheus block generated with token
+out="$(
+  render "export TRIGGER_PROM_QUERY='avg(rate(container_cpu_usage_seconds_total[5m])) > 0.8'; \
+          export TRIGGER_PROM_URL='http://prometheus:9090'; \
+          export TRIGGER_PROM_TOKEN='prom-secret-token'"
+)"
+echo "$out" | grep -q '^triggers:' || fail "triggers missing when TRIGGER_PROM_QUERY is set"
+echo "$out" | grep -q 'type: prometheus' || fail "type: prometheus missing"
+echo "$out" | grep -q 'query: "avg(rate(container_cpu_usage_seconds_total\[5m\])) > 0.8"' || fail "prometheus query not rendered"
+echo "$out" | grep -q 'prometheus_url: "http://prometheus:9090"' || fail "prometheus_url not rendered"
+echo "$out" | grep -q 'prometheus_bearer_token: "prom-secret-token"' || fail "prometheus_bearer_token not rendered"
+
+# Case 7: TRIGGER_PROM_QUERY set without token -> no bearer_token line
+out="$(
+  render "export TRIGGER_PROM_QUERY='up{job=\"krkn\"} == 1'; \
+          export TRIGGER_PROM_URL='http://prom.local:9090'"
+)"
+echo "$out" | grep -q 'type: prometheus' || fail "type: prometheus missing without token"
+echo "$out" | grep -q 'prometheus_url: "http://prom.local:9090"' || fail "prometheus_url not rendered without token"
+if echo "$out" | grep -A5 'type: prometheus' | grep -q 'prometheus_bearer_token:'; then
+  fail "prometheus_bearer_token rendered when TRIGGER_PROM_TOKEN is empty"
 fi
 
 echo "PASS: triggers config rendering"

--- a/env.sh
+++ b/env.sh
@@ -95,6 +95,9 @@ export TRIGGER_K8S_KIND=${TRIGGER_K8S_KIND:=""}
 export TRIGGER_K8S_NAME=${TRIGGER_K8S_NAME:=""}
 export TRIGGER_K8S_NAMESPACE=${TRIGGER_K8S_NAMESPACE:=""}
 export TRIGGER_K8S_CONDITION=${TRIGGER_K8S_CONDITION:=""}
+export TRIGGER_PROM_QUERY=${TRIGGER_PROM_QUERY:=""}
+export TRIGGER_PROM_URL=${TRIGGER_PROM_URL:=""}
+export TRIGGER_PROM_TOKEN=${TRIGGER_PROM_TOKEN:=""}
 export TRIGGERS_MODE=${TRIGGERS_MODE:="all_of"}
 export TRIGGERS_TIMEOUT=${TRIGGERS_TIMEOUT:="300"}
 export TRIGGERS_INTERVAL=${TRIGGERS_INTERVAL:="5"}
@@ -139,9 +142,16 @@ build_triggers_block() {
     block+="      condition: \"$TRIGGER_K8S_CONDITION\"\n"
   fi
 
+  if [[ -n "$TRIGGER_PROM_QUERY" ]]; then
+    block+="    - type: prometheus\n"
+    block+="      query: \"$TRIGGER_PROM_QUERY\"\n"
+    block+="      prometheus_url: \"$TRIGGER_PROM_URL\"\n"
+    [[ -n "$TRIGGER_PROM_TOKEN" ]] && block+="      prometheus_bearer_token: \"$TRIGGER_PROM_TOKEN\"\n"
+  fi
+
   printf '%b' "$block"
 }
 
-if [[ -n "$TRIGGER_COMMAND" ]] || [[ -n "$TRIGGER_HTTP_URL" ]] || [[ -n "$TRIGGER_K8S_API_VERSION" ]]; then
+if [[ -n "$TRIGGER_COMMAND" ]] || [[ -n "$TRIGGER_HTTP_URL" ]] || [[ -n "$TRIGGER_K8S_API_VERSION" ]] || [[ -n "$TRIGGER_PROM_QUERY" ]]; then
   export TRIGGERS_BLOCK="$(build_triggers_block)"
 fi


### PR DESCRIPTION
Support the new prometheus trigger added in krkn#1517. Adds TRIGGER_PROM_QUERY, TRIGGER_PROM_URL, and TRIGGER_PROM_TOKEN env vars so chaos can gate on a PromQL condition before injection.

## Description  
<!-- Provide a brief description of the changes made in this PR. -->  

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/). 

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  