### PR TITLE
fix(node-memory-hog): use correct YAML field name for memory consumption

### DIFF
--- a/node-memory-hog/memory-hog.yml.template
+++ b/node-memory-hog/memory-hog.yml.template
@@ -6,5 +6,5 @@ image: $IMAGE
 node-selector: $NODE_SELECTOR
 number-of-nodes: $NUMBER_OF_NODES
 taints: $TAINTS
-vm-bytes: $MEMORY_CONSUMPTION_PERCENTAGE
+memory-vm-bytes: $MEMORY_CONSUMPTION_PERCENTAGE
 


### PR DESCRIPTION
## Summary

- Fixes `--memory-consumption` flag being silently ignored due to a YAML field name mismatch between krkn-hub and krkn-lib.
- Renames `vm-bytes` to `memory-vm-bytes` in `node-memory-hog/memory-hog.yml.template` to match what `HogConfig.from_yaml_dict()` expects.

## Root Cause

The template used `vm-bytes` but krkn-lib's `HogConfig.from_yaml_dict()` only reads `memory-vm-bytes`. This caused the user-supplied value to be dropped and the default `10%` to always be used.

## Test plan

- [ ] Deploy node-memory-hog scenario with `--memory-consumption 77%`
- [ ] Verify pod env shows `VM_BYTES=77%` instead of `10%`

Closes #372

Made with [Cursor](https://cursor.com)