### PR TITLE
added html parameter and changed format of html and pdf parameters

### DIFF
--- a/config.yaml.template
+++ b/config.yaml.template
@@ -5,7 +5,7 @@ kraken:
     publish_kraken_status: $PUBLISH_KRAKEN_STATUS
     signal_state: $SIGNAL_STATE                            # Will wait for the RUN signal when set to PAUSE before running the scenarios
     signal_address: $SIGNAL_ADDRESS                        # Signal listening address
-    generate_pdf_report: $GENERATE_PDF_REPORT
+    report_formats: $REPORT_FORMATS                        # PDF/HTML summary of scenario outputs
     chaos_scenarios:                                       # List of policies/chaos scenarios to load
         - $SCENARIO_TYPE:                                  # List of chaos time scenarios to load
             - $SCENARIO_FILE

--- a/env.sh
+++ b/env.sh
@@ -19,7 +19,7 @@ export CAPTURE_METRICS=${CAPTURE_METRICS:=False}
 export ENABLE_ALERTS=${ENABLE_ALERTS:=False}
 export ALERTS_PATH=${ALERTS_PATH:=config/alerts.yaml}
 export METRICS_PATH=${METRICS_PATH:=config/metrics-aggregated.yaml}
-export GENERATE_PDF_REPORT=${GENERATE_PDF_REPORT:=True}
+export REPORT_FORMATS=${REPORT_FORMATS:="[pdf,html]"}
 
 export ENABLE_ES=${ENABLE_ES:=False}
 export ES_SERVER=${ES_SERVER:=http://0.0.0.0}


### PR DESCRIPTION
## Description  
Replace the separate PDF/HTML report configuration with a single REPORT_FORMATS environment variable in Krkn-hub.

Changes
- Add REPORT_FORMATS to env.sh, defaulting to an empty list:
`export REPORT_FORMATS="${REPORT_FORMATS:-[]}"`
- Update config.yaml.template to pass the value directly to Krkn:
`report_formats: $REPORT_FORMATS`

## Documentation  
- [x] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/). 

## Related Documentation PR (if applicable)  
https://github.com/krkn-chaos/website/pull/603