### PR TITLE
Fix typo in io-block-size key

### DIFF
--- a/node-io-hog/io-hog.yml.template
+++ b/node-io-hog/io-hog.yml.template
@@ -1,6 +1,6 @@
 hog-type: io
 duration: $TOTAL_CHAOS_DURATION
-io-block_size: $IO_BLOCK_SIZE
+io-block-size: $IO_BLOCK_SIZE
 io-workers: $IO_WORKERS
 io-write-bytes: $IO_WRITE_BYTES
 image: $IMAGE


### PR DESCRIPTION
Fix property name mismatches in node-io-hog template

Align io-hog.yml.template with upstream krkn config:
- io-block_size -> io-block-size (underscore to hyphen)
