### PR TITLE
fix(network-chaos): add missing punctuation to descriptions

### DIFF
--- a/network-chaos/krknctl-input.json
+++ b/network-chaos/krknctl-input.json
@@ -2,7 +2,7 @@
     {
         "name": "traffic-type",
         "short_description": "Traffic Type",
-        "description": "Selects the network chaos scenario type can be ingress or egress",
+        "description": "Selects the network chaos scenario type can be ingress or egress.",
         "variable": "TRAFFIC_TYPE",
         "type": "enum",
         "allowed_values": "ingress,egress",
@@ -12,7 +12,7 @@
     {
         "name": "image",
         "short_description": "Image",
-        "description": "Image used to disrupt network on a pod",
+        "description": "Image used to disrupt network on a pod.",
         "variable": "IMAGE",
         "type": "string",
         "default": "quay.io/krkn-chaos/krkn:tools",
@@ -59,7 +59,7 @@
     {
         "name": "node-name",
         "short_description": "Node Name [*Egress only*]",
-        "description": "Node name to inject faults in case of targeting a specific node; Can set multiple node names separated by a comma",
+        "description": "Node name to inject faults in case of targeting a specific node; Can set multiple node names separated by a comma.",
         "type": "string",
         "variable": "NODE_NAME",
         "default": "",
@@ -68,7 +68,7 @@
     {
         "name": "interfaces",
         "short_description": "Interfaces [*Egress only*]",
-        "description": "List of interface on which to apply the network restriction. eg. [eth0,eth1,eth2]",
+        "description": "List of interface on which to apply the network restriction. eg. [eth0,eth1,eth2].",
         "type": "string",
         "variable": "INTERFACES",
         "default": "[]",
@@ -79,7 +79,7 @@
     {
         "name": "egress",
         "short_description": "Egress [*Egress only*]",
-        "description": "Dictionary of values to set network latency(latency: 50ms), packet loss(loss: 0.02), bandwidth restriction(bandwidth: 100mbit) eg. {bandwidth: 100mbit}",
+        "description": "Dictionary of values to set network latency(latency: 50ms), packet loss(loss: 0.02), bandwidth restriction(bandwidth: 100mbit) eg. {bandwidth: 100mbit}.",
         "type": "string",
         "variable": "EGRESS",
         "default": "{bandwidth: 100mbit}",
@@ -90,7 +90,7 @@
     {
         "name": "target-node-interface",
         "short_description": "Target Node and Interfaces [*Ingress only*]",
-        "description": "Dictionary with key as node name(s) and value as a list of its interfaces to test. For example: {ip-10-0-216-2.us-west-2.compute.internal: [ens5]}",
+        "description": "Dictionary with key as node name(s) and value as a list of its interfaces to test. For example: {ip-10-0-216-2.us-west-2.compute.internal: [ens5]}.",
         "type": "string",
         "variable": "TARGET_NODE_AND_INTERFACE",
         "validator": "^{([a-zA-Z0-9-.]+: \\[(([A-Za-z0-9._-]+(,)?)+)\\](,)?)+}$",
@@ -100,7 +100,7 @@
     {
         "name": "network-params",
         "short_description": "Network Params [*Ingress only*]",
-        "description": "latency, loss and bandwidth are the three supported network parameters to alter for the chaos test. For example: {latency: 50ms, loss: 0.02}",
+        "description": "latency, loss and bandwidth are the three supported network parameters to alter for the chaos test. For example: {latency: 50ms, loss: 0.02}.",
         "type": "string",
         "variable": "NETWORK_PARAMS",
         "validator": "^{((latency|loss|bandwidth): [a-zA-Z0-9.]+(,)?)+[^,]}$",
@@ -110,7 +110,7 @@
     {
         "name": "wait-duration",
         "short_description": "Wait Duration [*Ingress only*]",
-        "description": "Ensure that it is at least about twice of test_duration",
+        "description": "Ensure that it is at least about twice of test_duration.",
         "type": "number",
         "variable": "WAIT_DURATION",
         "default": "300",


### PR DESCRIPTION
Small change PR to test doc-sync-bot trigger. No major changes in the code — just adds trailing periods to description fields in `network-chaos/krknctl-input.json` for consistency.

Made with [Cursor](https://cursor.com)