### PR TITLE
fix(application-outages): use correct bash default-value assignment syntax

### DIFF
--- a/application-outages/env.sh
+++ b/application-outages/env.sh
@@ -4,7 +4,7 @@
 export DURATION=${DURATION:=600}
 export NAMESPACE=${NAMESPACE:=<namespace>}
 export POD_SELECTOR=${POD_SELECTOR:="{}"}
-export EXCLUDE_LABEL=${EXCLUDE_LABEL:""}
+export EXCLUDE_LABEL=${EXCLUDE_LABEL:=""}
 export BLOCK_TRAFFIC_TYPE=${BLOCK_TRAFFIC_TYPE:=- Ingress}
 export SCENARIO_TYPE=${SCENARIO_TYPE:=application_outages_scenarios}
 export SCENARIO_FILE=${SCENARIO_FILE:=scenarios/app_outage.yaml}


### PR DESCRIPTION
## Summary
- Fixes incorrect bash parameter expansion `${EXCLUDE_LABEL:""}` (substring expansion) to `${EXCLUDE_LABEL:=""}` (default assignment) in `application-outages/env.sh`
- Without the `=`, the variable does not get assigned the intended default value when unset

## Test plan
- [ ] Verify `EXCLUDE_LABEL` defaults to empty string when unset by sourcing `application-outages/env.sh`
- [ ] Confirm no regression in existing scripts that rely on this variable


Made with [Cursor](https://cursor.com)