### PR TITLE
Moving to vmi outage name

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 SCENARIOS=( application-outages container-scenarios network-chaos node-cpu-hog node-io-hog \
 node-memory-hog node-scenarios node-scenarios-bm pod-network-chaos pod-scenarios power-outages pvc-scenario \
-service-disruption-scenarios service-hijacking syn-flood time-scenarios zone-outages node-network-filter pod-network-filter kubevirt-outage node-interface-down http-load rollback vmi-network-filter vmi-network \
+service-disruption-scenarios service-hijacking syn-flood time-scenarios zone-outages node-network-filter pod-network-filter kubevirt-outage vmi-outage node-interface-down http-load rollback vmi-network-filter vmi-network \
 dummy-scenario storage-throttle node-network-chaos)
 for i in "${SCENARIOS[@]}"; do
     export KRKNCTL_INPUT=$(cat $i/krknctl-input.json|tr -d "\n")

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -119,11 +119,16 @@ services:
         context: ./
         dockerfile: ./syn-flood/Dockerfile
       image: quay.io/krkn-chaos/krkn-hub:syn-flood
-    kubevirt-outage:
+    kubevirt-outage:  # Deprecated: use vmi-outage instead
       build:
         context: ./
         dockerfile: ./kubevirt-outage/Dockerfile
       image: quay.io/krkn-chaos/krkn-hub:kubevirt-outage
+    vmi-outage:
+      build:
+        context: ./
+        dockerfile: ./vmi-outage/Dockerfile
+      image: quay.io/krkn-chaos/krkn-hub:vmi-outage
     vmi-network-filter:
       build:
         context: ./

--- a/kubevirt-outage/.deprecated
+++ b/kubevirt-outage/.deprecated
@@ -1,0 +1,11 @@
+This directory is deprecated and maintained only for backwards compatibility.
+
+New users should use: vmi-outage/
+
+The kubevirt-outage container image will continue to work but will be removed
+in a future release. Please migrate to vmi-outage.
+
+Migration is simple - just change your container image from:
+  quay.io/krkn-chaos/krkn-hub:kubevirt-outage
+to:
+  quay.io/krkn-chaos/krkn-hub:vmi-outage

--- a/kubevirt-outage/README.md
+++ b/kubevirt-outage/README.md
@@ -1,3 +1,6 @@
 # Kubevirt Outage Scenario Docs
 
-See [doc](https://krkn-chaos.dev/docs/scenarios/kubevirt-vm-outage-scenario/#tab-krkn-hub) for background, how to run and all the variables listed
+> **⚠️ DEPRECATED**: This image name is deprecated. Please use `vmi-outage` instead.  
+> This image is maintained for backwards compatibility and will be removed in a future release.
+
+See [doc](https://krkn-chaos.dev/docs/scenarios/vmi-outage/#tab-krkn-hub) for background, how to run and all the variables listed

--- a/kubevirt-outage/env.sh
+++ b/kubevirt-outage/env.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
+# DEPRECATED: This image is maintained for backwards compatibility
+# Please use vmi-outage instead
+
 # Vars and respective defaults
 export NAMESPACE=${NAMESPACE:=""}
 export VM_NAME=${VM_NAME:=""}
 export LABEL_SELECTOR=${LABEL_SELECTOR:=""}
 export TIMEOUT=${TIMEOUT:=60}
 export KILL_COUNT=${KILL_COUNT:=1}
+# Legacy scenario type name - still supported by krkn for backwards compatibility
 export SCENARIO_TYPE=${SCENARIO_TYPE:=kubevirt_vm_outage}
 export SCENARIO_FILE=${SCENARIO_FILE:=scenarios/kubevirt_scenario.yaml}

--- a/vmi-outage/Dockerfile.template
+++ b/vmi-outage/Dockerfile.template
@@ -1,0 +1,24 @@
+# Dockerfile for kraken
+
+FROM quay.io/krkn-chaos/krkn:latest
+
+ENV KUBECONFIG /home/krkn/.kube/config
+
+# Copy configurations
+COPY config.yaml.template /home/krkn/kraken/config/config.yaml.template
+COPY metrics_config.yaml.template /home/krkn/kraken/config/kube_burner.yaml.template
+COPY vmi-outage/env.sh /home/krkn/env.sh
+COPY env.sh /home/krkn/main_env.sh
+COPY vmi-outage/run.sh /home/krkn/run.sh
+COPY vmi-outage/vmi_scenario.yaml.template /home/krkn/kraken/scenarios/vmi_scenario.yaml.template
+COPY common_run.sh /home/krkn/common_run.sh
+USER krkn
+
+LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.has_rollback="false"
+LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
+LABEL krknctl.title="VMI Outage Scenarios"
+LABEL krknctl.description="Scenario to delete a VMI in a CNV/Virtualization cluster. More information can be found at https://krkn-chaos.dev/docs/scenarios/vmi-outage/"
+LABEL krknctl.input_fields='$KRKNCTL_INPUT'
+
+ENTRYPOINT /home/krkn/kraken/containers/setup-ssh.sh && /home/krkn/run.sh

--- a/vmi-outage/README.md
+++ b/vmi-outage/README.md
@@ -1,0 +1,3 @@
+# VMI Outage Scenario Docs
+
+See [doc](https://krkn-chaos.dev/docs/scenarios/vmi-outage/#tab-krkn-hub) for background, how to run and all the variables listed

--- a/vmi-outage/env.sh
+++ b/vmi-outage/env.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Vars and respective defaults
+export NAMESPACE=${NAMESPACE:=""}
+export VM_NAME=${VM_NAME:=""}
+export LABEL_SELECTOR=${LABEL_SELECTOR:=""}
+export TIMEOUT=${TIMEOUT:=60}
+export KILL_COUNT=${KILL_COUNT:=1}
+export SCENARIO_TYPE=${SCENARIO_TYPE:=vmi_outage}
+export SCENARIO_FILE=${SCENARIO_FILE:=scenarios/vmi_scenario.yaml}

--- a/vmi-outage/krknctl-input.json
+++ b/vmi-outage/krknctl-input.json
@@ -1,0 +1,47 @@
+[
+    {
+        "name": "namespace",
+        "short_description": "Namespace",
+        "description": "Targeted namespace in the cluster",
+        "variable": "NAMESPACE",
+        "type": "string",
+        "default": "default",
+        "required": "true"
+    },
+    {
+        "name": "vm-name",
+        "short_description": "VM Name",
+        "description": "Name of the vm to delete. Optional if label-selector is set",
+        "type": "string",
+        "variable": "VM_NAME",
+        "default": "",
+        "required": "false"
+    },
+    {
+        "name": "label-selector",
+        "short_description": "Label Selector",
+        "description": "Label selector to target VMs (e.g. app=myvm). Optional if vm-name is set",
+        "type": "string",
+        "variable": "LABEL_SELECTOR",
+        "default": "",
+        "required": "false"
+    },
+    {
+        "name": "timeout",
+        "short_description": "Timeout",
+        "description": "Time that scneario will wait for VM to come back",
+        "variable": "TIMEOUT",
+        "type": "number",
+        "default": "60",
+        "required": "false"
+    },
+    {
+        "name": "kill-count",
+        "short_description": "Kill Count",
+        "description": "Number of VMIs to kill (performed serially)",
+        "variable": "KILL_COUNT",
+        "type": "number",
+        "default": "1",
+        "required": "false"
+    }
+]

--- a/vmi-outage/run.sh
+++ b/vmi-outage/run.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Source env.sh to read all the vars
+source /home/krkn/main_env.sh
+source /home/krkn/env.sh
+source /home/krkn/common_run.sh
+
+if [[ $KRKN_DEBUG == "True" ]];then
+  set -ex
+fi
+
+
+checks
+
+# Substitute config with environment vars defined
+envsubst < /home/krkn/kraken/scenarios/vmi_scenario.yaml.template > /home/krkn/kraken/scenarios/vmi_scenario.yaml
+envsubst < /home/krkn/kraken/config/config.yaml.template > /home/krkn/kraken/config/vmi_scenario_config.yaml
+
+# Run Kraken
+cd /home/krkn/kraken
+extra_var=""
+if [[ $KRKN_DEBUG == "True" ]];then
+  cat config/vmi_scenario_config.yaml
+  cat scenarios/vmi_scenario.yaml
+  extra_var="--debug True"
+fi
+
+
+
+python3.11 run_kraken.py --config=config/vmi_scenario_config.yaml $extra_var

--- a/vmi-outage/vmi_scenario.yaml.template
+++ b/vmi-outage/vmi_scenario.yaml.template
@@ -1,0 +1,9 @@
+scenarios:
+  - name: "vmi outage test"
+    scenario: vmi_outage
+    parameters:
+      vm_name: $VM_NAME
+      label_selector: $LABEL_SELECTOR
+      namespace: $NAMESPACE
+      timeout: $TIMEOUT
+      kill_count: $KILL_COUNT


### PR DESCRIPTION
## Description  
After https://github.com/krkn-chaos/krkn/pull/1582 merges, need to update to vmi-outage 

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/). 

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  