### PR TITLE
fix: use correct bash default-value assignment syntax in env.sh files

### DIFF
--- a/container-scenarios/env.sh
+++ b/container-scenarios/env.sh
@@ -3,7 +3,7 @@
 # Vars and respective defaults
 export NAMESPACE=${NAMESPACE:="openshift-etcd"}
 export LABEL_SELECTOR=${LABEL_SELECTOR:="k8s-app=etcd"}
-export EXCLUDE_LABEL=${EXCLUDE_LABEL:""}
+export EXCLUDE_LABEL=${EXCLUDE_LABEL:=""}
 export EXPECTED_RECOVERY_TIME=${EXPECTED_RECOVERY_TIME:=60}
 export DISRUPTION_COUNT=${DISRUPTION_COUNT:=1}
 export CONTAINER_NAME=${CONTAINER_NAME:=etcd}

--- a/env.sh
+++ b/env.sh
@@ -72,9 +72,9 @@ export KUBE_VIRT_NAME=${KUBE_VIRT_NAME:=""}
 export KUBE_VIRT_LABEL_SELECTOR=${KUBE_VIRT_LABEL_SELECTOR:=""}
 export KUBE_VIRT_FAILURES=${KUBE_VIRT_FAILURES:=False}
 export KUBE_VIRT_DISCONNECTED=${KUBE_VIRT_DISCONNECTED:=False}
-export KUBE_VIRT_SSH_NODE=${KUBE_VIRT_SSH_NODE:""}
-export KUBE_VIRT_NODE_NAME=${KUBE_VIRT_NODE_NAME:""}                                     # Filter only VMI's running a specific node name
-export KUBE_VIRT_EXIT_ON_FAIL=${KUBE_VIRT_EXIT_ON_FAIL:False}
+export KUBE_VIRT_SSH_NODE=${KUBE_VIRT_SSH_NODE:=""}
+export KUBE_VIRT_NODE_NAME=${KUBE_VIRT_NODE_NAME:=""}                                     # Filter only VMI's running a specific node name
+export KUBE_VIRT_EXIT_ON_FAIL=${KUBE_VIRT_EXIT_ON_FAIL:=False}
 
 # resiliency score
 export RESILIENCY_RUN_MODE=${RESILIENCY_RUN_MODE:="standalone"}


### PR DESCRIPTION
## Summary
- Fixes incorrect bash parameter expansion in `env.sh` and `container-scenarios/env.sh`
- Replaces `${VAR:""}` / `${VAR:False}` (substring expansion) with `${VAR:=""}` / `${VAR:=False}` (default assignment) so variables get their intended defaults when unset
- Complements #382, which fixed the same issue in `application-outages/env.sh`

## Affected variables
- `env.sh`: `KUBE_VIRT_SSH_NODE`, `KUBE_VIRT_NODE_NAME`, `KUBE_VIRT_EXIT_ON_FAIL`
- `container-scenarios/env.sh`: `EXCLUDE_LABEL`

## Test plan
- [ ] Source `env.sh` and verify `KUBE_VIRT_*` variables default correctly when unset
- [ ] Source `container-scenarios/env.sh` and verify `EXCLUDE_LABEL` defaults to empty string when unset


Made with [Cursor](https://cursor.com)