### PR TITLE
Prepare scenarios for signed images (krkn base image + krknctl.privileged label)

### DIFF
--- a/application-outages/Dockerfile.template
+++ b/application-outages/Dockerfile.template
@@ -14,6 +14,7 @@ COPY common_run.sh /home/krkn/common_run.sh
 COPY application-outages/app_outages.yaml.template /home/krkn/kraken/scenarios/app_outage.yaml.template
 
 LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.privileged="false"
 LABEL krknctl.has_rollback="true"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="Application Outages"

--- a/container-scenarios/Dockerfile.template
+++ b/container-scenarios/Dockerfile.template
@@ -15,6 +15,7 @@ COPY common_run.sh /home/krkn/common_run.sh
 USER krkn
 
 LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.privileged="false"
 LABEL krknctl.has_rollback="false"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="Container Scenarios"

--- a/dummy-scenario/Dockerfile.template
+++ b/dummy-scenario/Dockerfile.template
@@ -1,16 +1,16 @@
-FROM registry.access.redhat.com/ubi9-minimal:9.6-1752587672
-RUN groupadd -g 1001 krkn && useradd -m -u 1001 -g krkn krkn
-COPY dummy-scenario/run.sh /home/krkn
+FROM quay.io/krkn-chaos/krkn:latest
 
-LABEL krknctl.title.global="Krkn Base Image"
-LABEL krknctl.description.global="This is the krkn base image."
-LABEL krknctl.input_fields.global='[]'
+# Global input fields (cerberus, telemetry, ES, health-checks, ...) are inherited
+# from the krkn base image, so they don't need to be redeclared here.
+COPY dummy-scenario/run.sh /home/krkn/run.sh
 
 LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.privileged="false"
 LABEL krknctl.has_rollback="true"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="Dummy Scenario"
 LABEL krknctl.description="The dummy scenario simply waits for a specified amount of time without introducing any chaos. It serves as a root node in a flat graph structure to run multiple scenarios in parallel or can be used for testing purposes."
+
 LABEL krknctl.input_fields='$KRKNCTL_INPUT'
-USER krkn
+
 ENTRYPOINT ["bash", "/home/krkn/run.sh"]

--- a/http-load/Dockerfile.template
+++ b/http-load/Dockerfile.template
@@ -14,6 +14,7 @@ COPY http-load/run.sh /home/krkn/run.sh
 COPY common_run.sh /home/krkn/common_run.sh
 
 LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.privileged="false"
 LABEL krknctl.has_rollback="true"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="HTTP Load"

--- a/kubevirt-outage/Dockerfile.template
+++ b/kubevirt-outage/Dockerfile.template
@@ -15,6 +15,7 @@ COPY common_run.sh /home/krkn/common_run.sh
 USER krkn
 
 LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.privileged="false"
 LABEL krknctl.has_rollback="false"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="Kubevirt Outage Scenarios"

--- a/network-chaos/Dockerfile.template
+++ b/network-chaos/Dockerfile.template
@@ -15,6 +15,7 @@ COPY network-chaos/network_chaos_egress.yaml.template /home/krkn/kraken/scenario
 COPY network-chaos/network_chaos_ingress.yaml.template /home/krkn/kraken/scenarios/network_chaos_ingress.yaml.template
 
 LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.privileged="false"
 LABEL krknctl.has_rollback="false"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="Network Chaos"

--- a/node-cpu-hog/Dockerfile.template
+++ b/node-cpu-hog/Dockerfile.template
@@ -12,6 +12,7 @@ COPY node-cpu-hog/cpu-hog.yml.template /home/krkn/kraken/scenarios/kube/cpu-hog.
 COPY common_run.sh /home/krkn/common_run.sh
 
 LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.privileged="true"
 LABEL krknctl.has_rollback="true"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="CPU Hog"

--- a/node-interface-down/Dockerfile.template
+++ b/node-interface-down/Dockerfile.template
@@ -15,6 +15,7 @@ COPY node-interface-down/node-interface-down.yml /home/krkn/kraken/scenarios/kub
 COPY common_run.sh /home/krkn/common_run.sh
 
 LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.privileged="true"
 LABEL krknctl.has_rollback="false"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="Node Interface Down"

--- a/node-io-hog/Dockerfile.template
+++ b/node-io-hog/Dockerfile.template
@@ -14,6 +14,7 @@ COPY node-io-hog/io-hog.yml.template /home/krkn/kraken/scenarios/kube/io-hog.yml
 COPY common_run.sh /home/krkn/common_run.sh
 
 LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.privileged="true"
 LABEL krknctl.has_rollback="true"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="I/O Hog"

--- a/node-memory-hog/Dockerfile.template
+++ b/node-memory-hog/Dockerfile.template
@@ -15,6 +15,7 @@ COPY node-memory-hog/memory-hog.yml.template /home/krkn/kraken/scenarios/kube/me
 COPY common_run.sh /home/krkn/common_run.sh
 
 LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.privileged="true"
 LABEL krknctl.has_rollback="true"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="Memory Hog"

--- a/node-network-filter/Dockerfile.template
+++ b/node-network-filter/Dockerfile.template
@@ -15,6 +15,7 @@ COPY node-network-filter/network-filter.yml /home/krkn/kraken/scenarios/kube/net
 COPY common_run.sh /home/krkn/common_run.sh
 
 LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.privileged="true"
 LABEL krknctl.has_rollback="false"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="Node Network Filter"

--- a/node-scenarios-bm/Dockerfile.template
+++ b/node-scenarios-bm/Dockerfile.template
@@ -21,6 +21,7 @@ COPY node-scenarios-bm/run.sh /home/krkn/run.sh
 COPY common_run.sh /home/krkn/common_run.sh
 
 LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.privileged="true"
 LABEL krknctl.has_rollback="false"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="Node scenarios Bare Metal"

--- a/node-scenarios/Dockerfile.template
+++ b/node-scenarios/Dockerfile.template
@@ -19,6 +19,7 @@ COPY node-scenarios/node_scenario.yaml.template /home/krkn/kraken/scenarios/node
 COPY node-scenarios/baremetal_node_scenario.yaml.template /home/krkn/kraken/scenarios/baremetal_node_scenario.yaml.template
 
 LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.privileged="true"
 LABEL krknctl.has_rollback="false"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="Node scenarios"

--- a/pod-network-chaos/Dockerfile.template
+++ b/pod-network-chaos/Dockerfile.template
@@ -14,6 +14,7 @@ COPY common_run.sh /home/krkn/common_run.sh
 COPY pod-network-chaos/pod_network_scenario.yaml.template /home/krkn/kraken/scenarios/pod_network_scenario.yaml.template
 
 LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.privileged="false"
 LABEL krknctl.has_rollback="false"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="Pod Network Chaos"

--- a/pod-network-filter/Dockerfile.template
+++ b/pod-network-filter/Dockerfile.template
@@ -15,6 +15,7 @@ COPY pod-network-filter/network-filter.yml /home/krkn/kraken/scenarios/kube/netw
 COPY common_run.sh /home/krkn/common_run.sh
 
 LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.privileged="false"
 LABEL krknctl.has_rollback="false"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="Pod Network Filter"

--- a/pod-scenarios/Dockerfile.template
+++ b/pod-scenarios/Dockerfile.template
@@ -15,6 +15,7 @@ COPY pod-scenarios/pod_scenario.yaml.template /home/krkn/kraken/scenarios/pod_sc
 COPY pod-scenarios/pod_scenario_namespace.yaml.template /home/krkn/kraken/scenarios/pod_scenario_namespace.yaml.template
 
 LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.privileged="false"
 LABEL krknctl.has_rollback="false"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="Pod Failures"

--- a/power-outages/Dockerfile.template
+++ b/power-outages/Dockerfile.template
@@ -15,6 +15,7 @@ COPY power-outages/post_action.py /home/krkn/kraken/scenarios/post_action.py
 COPY common_run.sh /home/krkn/common_run.sh
 
 LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.privileged="false"
 LABEL krknctl.has_rollback="false"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="Power outages"

--- a/pvc-scenario/Dockerfile.template
+++ b/pvc-scenario/Dockerfile.template
@@ -14,6 +14,7 @@ COPY common_run.sh /home/krkn/common_run.sh
 COPY pvc-scenario/pvc_scenario.yaml.template /home/krkn/kraken/scenarios/pvc_scenario.yaml.template
 
 LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.privileged="false"
 LABEL krknctl.has_rollback="true"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="PVC Disk Fill"

--- a/rollback/Dockerfile.template
+++ b/rollback/Dockerfile.template
@@ -10,6 +10,7 @@ COPY env.sh /home/krkn/main_env.sh
 COPY common_run.sh /home/krkn/common_run.sh
 
 LABEL krknctl.is_a_scenario="false"
+LABEL krknctl.privileged="false"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="Rollback"
 LABEL krknctl.description="This scenario will rollback a scenario based on the run uuid passed as parameter"

--- a/service-disruption-scenarios/Dockerfile.template
+++ b/service-disruption-scenarios/Dockerfile.template
@@ -14,6 +14,7 @@ COPY service-disruption-scenarios/namespace_scenario.yaml.template /home/krkn/kr
 COPY common_run.sh /home/krkn/common_run.sh
 
 LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.privileged="false"
 LABEL krknctl.has_rollback="false"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="Service Disruption"

--- a/service-hijacking/Dockerfile.template
+++ b/service-hijacking/Dockerfile.template
@@ -17,6 +17,7 @@ COPY service-hijacking/validate_config.py /home/krkn/validate_config.py
 COPY common_run.sh /home/krkn/common_run.sh
 
 LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.privileged="false"
 LABEL krknctl.has_rollback="true"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="Service Hijacking"

--- a/syn-flood/Dockerfile.template
+++ b/syn-flood/Dockerfile.template
@@ -15,6 +15,7 @@ COPY syn-flood/run.sh /home/krkn/run.sh
 COPY common_run.sh /home/krkn/common_run.sh
 
 LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.privileged="false"
 LABEL krknctl.has_rollback="true"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="Syn flood"

--- a/time-scenarios/Dockerfile.template
+++ b/time-scenarios/Dockerfile.template
@@ -14,6 +14,7 @@ COPY time-scenarios/time_scenario.yaml.template /home/krkn/kraken/scenarios/time
 COPY common_run.sh /home/krkn/common_run.sh
 
 LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.privileged="false"
 LABEL krknctl.has_rollback="false"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="Time skew"

--- a/vmi-network-filter/Dockerfile.template
+++ b/vmi-network-filter/Dockerfile.template
@@ -15,6 +15,7 @@ COPY vmi-network-filter/vmi-network-filter.yml /home/krkn/kraken/scenarios/kube/
 COPY common_run.sh /home/krkn/common_run.sh
 
 LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.privileged="false"
 LABEL krknctl.has_rollback="false"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="VMI Network Filter"

--- a/vmi-network/Dockerfile.template
+++ b/vmi-network/Dockerfile.template
@@ -15,6 +15,7 @@ COPY vmi-network/vmi-network-chaos.yml /home/krkn/kraken/scenarios/kube/vmi-netw
 COPY common_run.sh /home/krkn/common_run.sh
 
 LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.privileged="false"
 LABEL krknctl.has_rollback="false"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="VMI Network Chaos"

--- a/zone-outages/Dockerfile.template
+++ b/zone-outages/Dockerfile.template
@@ -15,6 +15,7 @@ COPY zone-outages/zone_outage_scenario_gcp.yaml.template /home/krkn/kraken/scena
 COPY common_run.sh /home/krkn/common_run.sh
 
 LABEL krknctl.is_a_scenario="true"
+LABEL krknctl.privileged="false"
 LABEL krknctl.has_rollback="true"
 LABEL krknctl.kubeconfig_path="/home/krkn/.kube/config"
 LABEL krknctl.title="Zone outage"


### PR DESCRIPTION
## Why

Preliminary work for **image signing & verification** across the krkn ecosystem — see the tracking issue **krkn-chaos/krknctl#180** (shared cosign-based signing/verification primitives, consumed by both krknctl and krkn-operator). These changes make the scenario images ready to be signed and to carry the metadata the operator/krknctl need at run time. No behavior change for existing users.

## What

### 1. `dummy-scenario` becomes a real scenario
Previously `dummy-scenario` was a standalone image based on `registry.access.redhat.com/ubi9-minimal`, creating its own `krkn` user and declaring empty global input fields. It now inherits from the real base image like every other scenario:

- `FROM quay.io/krkn-chaos/krkn:latest`
- global input fields (cerberus, telemetry, ES, health-checks, …) are **inherited from the base image**, so the `.global` LABELs and the `groupadd`/`useradd`/`USER` lines are dropped — the global-variable substitution is no longer needed
- `run.sh` and `krknctl-input.json` unchanged

This gives us a real, buildable/signable `quay.io/krkn-chaos/krkn-hub:dummy-scenario` image to exercise the operator verification path end-to-end.

### 2. New `krknctl.privileged` label on every scenario
A declarative metadata label the operator/krknctl will read to decide whether a scenario container needs a privileged security profile:

- **`true`** for the `node-*` scenarios (`node-cpu-hog`, `node-interface-down`, `node-io-hog`, `node-memory-hog`, `node-network-filter`, `node-scenarios`, `node-scenarios-bm`) — they operate at node level and require elevated privileges
- **`false`** for all others (default, least privilege)

Inserted right after `LABEL krknctl.is_a_scenario` for consistency.

> **Design note:** this label is *declarative intent*, not authorization. It will be honored **only for verified/signed images** (per krknctl#180) and always bounded by the OpenShift SCC / PodSecurity ceiling. The label alone must never be sufficient to obtain privilege.

## Notes

- Generated `Dockerfile`s are gitignored (`*/Dockerfile`); only `Dockerfile.template` is committed. `build.sh` regenerates them via `envsubst`.
- Build wiring for `dummy-scenario` (build.sh + docker-compose.yaml) was already present.
- Verified locally that the templates render correctly with `build.sh`'s `envsubst` step; the actual image build/test runs in CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)