### PR TITLE
fix(application-outages): use default instead of placeholder for NAMESPACE

### DIFF
--- a/application-outages/env.sh
+++ b/application-outages/env.sh
@@ -2,7 +2,7 @@
 
 # Vars and respective defaults
 export DURATION=${DURATION:=600}
-export NAMESPACE=${NAMESPACE:=<namespace>}
+export NAMESPACE=${NAMESPACE:=default}
 export POD_SELECTOR=${POD_SELECTOR:="{}"}
 export EXCLUDE_LABEL=${EXCLUDE_LABEL:=""}
 export BLOCK_TRAFFIC_TYPE=${BLOCK_TRAFFIC_TYPE:=- Ingress}


### PR DESCRIPTION
## Description

`application-outages/env.sh` declared `NAMESPACE` with a placeholder default:

```diff
-export NAMESPACE=${NAMESPACE:=<namespace>}
+export NAMESPACE=${NAMESPACE:=default}
```

`<namespace>` isn't a usable value, but as a declared literal the docs-sync bot renders it as `Default: <namespace>` in the generated parameter table — which reads as a real value a user could leave in place, even though the page's own prose says `NAMESPACE` is required. Sourcing `env.sh` with `NAMESPACE` unset also produced an invalid `namespace: <namespace>` in the rendered scenario YAML.

#386 originally proposed dropping the default entirely (`export NAMESPACE=${NAMESPACE}`). I went with `default` instead, per @paigerube14's comment on the issue: it's a namespace that exists on every cluster, so the scenario can run standalone if needed, while a user-supplied `NAMESPACE` still takes precedence.

**Verified locally:**

- `bash -n application-outages/env.sh` — syntax OK
- `NAMESPACE` unset → `default`
- `NAMESPACE=foo` → `foo` (user value wins)
- `NAMESPACE=` (empty) → `default` (`:=` treats empty as unset)
- `envsubst < app_outages.yaml.template` renders `namespace: default` and parses as valid YAML

The only other `<namespace>` in the repo is in `chaos-recommender/run.sh:19`, where it's correct — a usage message telling the user what to pass. Left unchanged.

**Note for reviewers:** `application-outages/krknctl-input.json` still lists `NAMESPACE` as `"required": "true"` with no `"default"`, so krknctl will keep prompting even though `env.sh` now has a fallback. Left as-is since #386 is scoped to the generated-docs problem, but happy to make them consistent in this PR if preferred.

## Documentation
- [ ] **Is documentation needed for this update?**

Unchecked — the parameter table regenerates automatically. `trigger-docs-sync.yml` watches `*/env.sh` on push to `main`, so merging this dispatches doc-sync for the `application-outages` scenario and the bot opens the website PR.

## Related Documentation PR (if applicable)

N/A — handled by the docs-sync bot on merge.
