### PR TITLE
ci: sign krkn-hub scenario images with cosign

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -62,6 +62,7 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
       - name: Build and push multi-platform image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -71,6 +72,30 @@ jobs:
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: ${{ steps.config.outputs.image }}
           provenance: false
+      # Sign the scenario image so krknctl / krkn-operator (via the shared
+      # pkg/verify package) can verify it before running. Sign by the digest
+      # emitted by build-push-action (anti-TOCTOU): consumers resolve the tag ->
+      # this digest and find the signature. Key-based, --tlog-upload=false, to
+      # match the ecosystem's offline verification policy (no Fulcio/Rekor).
+      - name: Install cosign
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: sigstore/cosign-installer@v4.1.2
+      - name: Sign scenario image with cosign
+        if: ${{ github.ref == 'refs/heads/main' }}
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          IMAGE: ${{ steps.config.outputs.image }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          REF="${IMAGE%:*}@${DIGEST}"
+          echo "Signing ${REF}"
+          cosign sign --yes --tlog-upload=false --key env://COSIGN_PRIVATE_KEY "${REF}"
+          # Self-check: fail the build if the signature does not verify with the
+          # public half of the signing key (derived on the fly, no extra secret).
+          cosign public-key --key env://COSIGN_PRIVATE_KEY > /tmp/cosign.pub
+          cosign verify --insecure-ignore-tlog=true --key /tmp/cosign.pub "${REF}"
 
   build-multiarch:
     runs-on: ubuntu-latest
@@ -118,6 +143,7 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
       - name: Build and push multi-platform image
+        id: build
         if: ${{ steps.config.outputs.image != '' }}
         uses: docker/build-push-action@v6
         with:
@@ -127,6 +153,25 @@ jobs:
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: ${{ steps.config.outputs.image }}
           provenance: false
+      # Sign the multi-arch scenario image by its manifest-list digest, same
+      # policy as build-amd64. Skipped for cerberus (empty image, amd64-only).
+      - name: Install cosign
+        if: ${{ github.ref == 'refs/heads/main' && steps.config.outputs.image != '' }}
+        uses: sigstore/cosign-installer@v4.1.2
+      - name: Sign scenario image with cosign
+        if: ${{ github.ref == 'refs/heads/main' && steps.config.outputs.image != '' }}
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          IMAGE: ${{ steps.config.outputs.image }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          REF="${IMAGE%:*}@${DIGEST}"
+          echo "Signing ${REF}"
+          cosign sign --yes --tlog-upload=false --key env://COSIGN_PRIVATE_KEY "${REF}"
+          cosign public-key --key env://COSIGN_PRIVATE_KEY > /tmp/cosign.pub
+          cosign verify --insecure-ignore-tlog=true --key /tmp/cosign.pub "${REF}"
 
   notify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Signs the **krkn-hub scenario images** with cosign on every push to `main`. These are the actual images that **krknctl** and **krkn-operator** pull and execute, so they are the most important to sign — they are the source of the runtime trust chain verified by the shared `pkg/verify` package.

Part of krkn-chaos/krknctl#180. Companion to the base-image signing (krkn-chaos/krkn#1588) and the runtime verification enforcement (krkn-chaos/krknctl#182).

## What changed (`.github/workflows/docker-image.yml`)

Both matrix build jobs now sign each scenario image right after it is pushed:

- **`build-amd64`** → signs `quay.io/krkn-chaos/krkn-hub:<scenario>`.
- **`build-multiarch`** → signs `quay.io/krkn-chaos/krkn-hub-multiarch:<scenario>` (skipped for cerberus, which stays amd64-only).
- **Sign by digest** using `build-push-action`'s `outputs.digest` (anti-TOCTOU) — consumers resolve the tag → this digest and find the signature; for multi-arch this is the manifest-list digest.
- **Key-based, `--tlog-upload=false`** — matches the ecosystem's fully-offline verification policy (no Fulcio/Rekor). Gated on push to `main` (no signing on PRs).
- **Self-verification** against the public half of the signing key (derived on the fly via `cosign public-key`, no extra secret) fails the build if signing is misconfigured.

## Required repository secrets (add before merge)

| Secret | Value |
|--------|-------|
| `COSIGN_PRIVATE_KEY` | the `cosign.key` from `cosign generate-key-pair` (encrypted PEM) |
| `COSIGN_PASSWORD` | the password protecting that private key |

Use the **same key pair** across the ecosystem (krkn base image, krkn-hub, and the `redhat-chaos/actions/krkn-hub` release-time rebuild). The matching public key must replace the placeholder embedded in krknctl's `pkg/verify/cosign.pub`.

## Note on the release-time rebuild path
`redhat-chaos/actions/krkn-hub` also rebuilds and pushes these tags during a krkn release (via `docker compose push`), which overwrites the digests signed here. That action must sign too (handled separately) so the live digests stay signed after a release.

## Testing
- Workflow validated with `actionlint` (clean) and YAML-parsed.
- Signing exercises only on a real `main` push (needs the secrets); the in-step `cosign verify` self-check gates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)