### PR TITLE
fix(ci): sign with vendored no-tlog signing-config on cosign latest

### DIFF
--- a/.github/cosign/signing-config.json
+++ b/.github/cosign/signing-config.json
@@ -1,0 +1,23 @@
+{
+  "mediaType": "application/vnd.dev.sigstore.signingconfig.v0.2+json",
+  "caUrls": [
+    {
+      "url": "https://fulcio.sigstore.dev",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2022-04-13T20:06:15.000Z"
+      },
+      "operator": "sigstore.dev"
+    }
+  ],
+  "oidcUrls": [
+    {
+      "url": "https://oauth2.sigstore.dev/auth",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2022-04-13T20:06:15.000Z"
+      },
+      "operator": "sigstore.dev"
+    }
+  ]
+}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -75,8 +75,9 @@ jobs:
       # Sign the scenario image so krknctl / krkn-operator (via the shared
       # pkg/verify package) can verify it before running. Sign by the digest
       # emitted by build-push-action (anti-TOCTOU): consumers resolve the tag ->
-      # this digest and find the signature. Key-based, --tlog-upload=false, to
-      # match the ecosystem's offline verification policy (no Fulcio/Rekor).
+      # this digest and find the signature. Key-based, signed with a
+      # no-transparency-log signing-config, to match the ecosystem's offline
+      # verification policy (no Fulcio/Rekor/TSA).
       - name: Install cosign
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: sigstore/cosign-installer@v4.1.2
@@ -91,7 +92,15 @@ jobs:
           set -euo pipefail
           REF="${IMAGE%:*}@${DIGEST}"
           echo "Signing ${REF}"
-          cosign sign --yes --tlog-upload=false --key env://COSIGN_PRIVATE_KEY "${REF}"
+          # cosign 2.6+ deprecated --tlog-upload and made --tlog-upload=false
+          # incompatible with its signing-config flow. Sign key-based/offline
+          # (no Fulcio/Rekor/TSA) via a signing-config whose transparency-log and
+          # timestamp services are stripped. The config is vendored in-repo
+          # (.github/cosign/signing-config.json) so we don't depend on an upstream
+          # file that could move or disappear; signature format is unchanged, so
+          # offline verification in pkg/verify (krknctl / krkn-operator) is
+          # unaffected.
+          cosign sign --yes --signing-config "${GITHUB_WORKSPACE}/.github/cosign/signing-config.json" --key env://COSIGN_PRIVATE_KEY "${REF}"
           # Self-check: fail the build if the signature does not verify with the
           # public half of the signing key (derived on the fly, no extra secret).
           cosign public-key --key env://COSIGN_PRIVATE_KEY > /tmp/cosign.pub
@@ -169,7 +178,15 @@ jobs:
           set -euo pipefail
           REF="${IMAGE%:*}@${DIGEST}"
           echo "Signing ${REF}"
-          cosign sign --yes --tlog-upload=false --key env://COSIGN_PRIVATE_KEY "${REF}"
+          # cosign 2.6+ deprecated --tlog-upload and made --tlog-upload=false
+          # incompatible with its signing-config flow. Sign key-based/offline
+          # (no Fulcio/Rekor/TSA) via a signing-config whose transparency-log and
+          # timestamp services are stripped. The config is vendored in-repo
+          # (.github/cosign/signing-config.json) so we don't depend on an upstream
+          # file that could move or disappear; signature format is unchanged, so
+          # offline verification in pkg/verify (krknctl / krkn-operator) is
+          # unaffected.
+          cosign sign --yes --signing-config "${GITHUB_WORKSPACE}/.github/cosign/signing-config.json" --key env://COSIGN_PRIVATE_KEY "${REF}"
           cosign public-key --key env://COSIGN_PRIVATE_KEY > /tmp/cosign.pub
           cosign verify --insecure-ignore-tlog=true --key /tmp/cosign.pub "${REF}"
 


### PR DESCRIPTION
## Why

Scenario image signing fails on the current cosign (both the amd64 and multiarch jobs):

```
cosign sign --yes --tlog-upload=false --key env://COSIGN_PRIVATE_KEY "${REF}"
Error: --tlog-upload=false is not supported with --signing-config or --use-signing-config.
```

`sigstore/cosign-installer@v4.1.2` installs **cosign 2.6+**, which deprecated `--tlog-upload` and made `--tlog-upload=false` incompatible with its new signing-config flow.

## What

Stay on **cosign latest** and use today's syntax: sign with a signing-config whose transparency-log **and** timestamp services are stripped, keeping key-based, **offline** signing (no Fulcio/Rekor/TSA).

The signing-config is **vendored in-repo** at `.github/cosign/signing-config.json` (derived from `sigstore/root-signing` with `del(.rekorTlogUrls, .rekorTlogConfig, .tsaUrls, .tsaConfig)`) instead of being `curl`'d at build time — so a moved/removed upstream file can never break signing. Both signing jobs already `actions/checkout` the repo, so the file is present.

```bash
cosign sign --yes --signing-config "${GITHUB_WORKSPACE}/.github/cosign/signing-config.json" --key env://COSIGN_PRIVATE_KEY "${REF}"
```

The signature **format is unchanged**, so offline key-based verification in `pkg/verify` (krknctl / krkn-operator) is unaffected. The in-pipeline `cosign verify --insecure-ignore-tlog=true` self-check still fails the build on a bad signature.

## Companion PRs (same fix, other repos)

- `krkn` → krkn-chaos/krkn#1589 (release manifest signing)
- `redhat-chaos/actions` (krkn-hub composite action) — release-time rebuild signing

🤖 Generated with [Claude Code](https://claude.com/claude-code)