### PR TITLE
Expose missing node scenario options in krknctl

### DIFF
--- a/node-scenarios/krknctl-input.json
+++ b/node-scenarios/krknctl-input.json
@@ -109,6 +109,28 @@
         "required": "false"
     },
     {
+        "name": "verify-session",
+        "short_description": "Verify Session [*VMware only*]",
+        "description": "Verify the vSphere client session using certificates",
+        "variable": "VERIFY_SESSION",
+        "type": "enum",
+        "allowed_values": "true,false",
+        "separator": ",",
+        "default": "false",
+        "required": "false"
+    },
+    {
+        "name": "skip-openshift-checks",
+        "short_description": "Skip OpenShift Checks [*VMware only*]",
+        "description": "Skip waiting for node status changes on OpenShift before completing the scenario",
+        "variable": "SKIP_OPENSHIFT_CHECKS",
+        "type": "enum",
+        "allowed_values": "true,false",
+        "separator": ",",
+        "default": "false",
+        "required": "false"
+    },
+    {
         "name": "vsphere-ip",
         "short_description": "VSphere IP [*VSphere only*]",
         "description": "vSphere IP address",


### PR DESCRIPTION
## Description

Expose the existing `VERIFY_SESSION` and `SKIP_OPENSHIFT_CHECKS` node scenario environment variables through `krknctl`. Both options use the same `false` defaults documented by `env.sh`, restoring parity between container and `krknctl` execution.

Fixes #390

## Validation

- `python3 -m json.tool node-scenarios/krknctl-input.json`
- `bash CI/tests/test_triggers_config.sh`
- verified option names and environment variable mappings are unique

## Documentation

- [ ] **Is documentation needed for this update?**

The existing node scenario documentation already describes both environment variables, and the repository's docs-sync workflow will propagate the updated `krknctl` schema after merge.

## Related Documentation PR (if applicable)

N/A